### PR TITLE
Injection iii zlli fork

### DIFF
--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -64,10 +64,12 @@
 }
 
 - (void)runInBackground {
+    [self writeString:[NSBundle mainBundle].privateFrameworksPath];
+    
     NSString *projectFile = [self readString];
     printf("Injection connected, watching %s/...\n",
            projectFile.stringByDeletingLastPathComponent.UTF8String);
-    [self writeString:[NSBundle mainBundle].privateFrameworksPath];
+    
 #ifdef __LP64__
     [self writeString:@"x86_64"];
 #else

--- a/InjectionIII/InjectionServer.mm
+++ b/InjectionIII/InjectionServer.mm
@@ -39,15 +39,6 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
 }
 
 - (void)runInBackground {
-    XcodeApplication *xcode = (XcodeApplication *)[SBApplication
-                       applicationWithBundleIdentifier:XcodeBundleID];
-    XcodeWorkspaceDocument *workspace = [xcode activeWorkspaceDocument];
-    NSString *projectFile = workspace.file.path, *projectRoot = projectFile.stringByDeletingLastPathComponent;
-    NSLog(@"Connection with project file: %@", projectFile);
-
-    // tell client app the inferred project being watched
-    [self writeString:projectFile];
-
     SwiftEval *builder = [SwiftEval new];
 
     // client spcific data for building
@@ -55,6 +46,32 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
         builder.frameworks = frameworks;
     else
         return;
+    
+    //traverse all workspaceDocuments and find out which workspace is connecting
+    NSString *projectFile;
+    NSString *projectRoot;
+    BOOL getProjectFile = NO;
+    XcodeApplication *xcode = (XcodeApplication *)[SBApplication
+                                                       applicationWithBundleIdentifier:XcodeBundleID];
+    for (XcodeWorkspaceDocument *tmpWorkspaceDocument in xcode.workspaceDocuments) {
+        NSString* projectName = [builder.frameworks stringByDeletingLastPathComponent];
+        projectName = [[projectName lastPathComponent] stringByDeletingPathExtension];
+        
+        if ([tmpWorkspaceDocument.file.path containsString:projectName]) {
+            projectFile = tmpWorkspaceDocument.file.path;
+            projectRoot = projectFile.stringByDeletingLastPathComponent;
+            NSLog(@"Connection with project file: %@", projectFile);
+            builder.projectFile = projectFile;
+            // tell client app the inferred project being watched
+            [self writeString:projectFile];
+            getProjectFile = YES;
+            break;
+        }
+    }
+    
+    if (getProjectFile == NO) {
+        return;
+    }
 
     if (NSString *arch = [self readString])
         builder.arch = arch;
@@ -65,9 +82,6 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
     if (NSRunningApplication *xcode = [NSRunningApplication
                                        runningApplicationsWithBundleIdentifier:XcodeBundleID].firstObject)
         builder.xcodeDev = [xcode.bundleURL.path stringByAppendingPathComponent:@"Contents/Developer"];
-
-
-    builder.projectFile = projectFile;
 
     NSString *projectName = projectFile.stringByDeletingPathExtension.lastPathComponent;
     NSString *derivedLogs = [NSString stringWithFormat:@"%@/Library/Developer/Xcode/DerivedData/%@-%@/Logs/Build",


### PR DESCRIPTION
fix “get wrong connection project” problem

I found a “get wrong connection project” problem,causes the injection function to be unavailable.

see this log:
“2018-06-19 18:27:23.907189+0800 InjectionIII[61600:2282765] Connection with project file: /Users/zhaolei/Documents/demo/InjectionIII/InjectionIII.xcodeproj”

The reason for the problem : xcode.activeWorkspaceDocument is related to the project opening order，when I open a testProject before open InjectionIIIProject.And run both xcode(try to connect),xcode.activeWorkspaceDocument point to InjectionIIIProject(can see the above log)

I fixed this problem and have tested it: get connecting project Name from frameworkPath (client write to server), and traverse all workspaceDocuments to find out which project is connecting,  if it doesn’t find a workspace with the binary's name,then fall-back to the activeWorkspaceDocument.file.path.