### PR TITLE
Set indent and tab width on Xcode project

### DIFF
--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -215,7 +215,9 @@
 				BB439B661FABA64300B4F50B /* Products */,
 				BBB040621FB1798A007DDD0A /* Frameworks */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		BB439B661FABA64300B4F50B /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
These changes will make it easier for people to contribute while keeping a consistent code style.
Setting the indent and tab width on the Xcode project will override the preference of the developer,
what this means is that developers don't have to change their settings when working on the project.
The settings are set to 4 on both tab and indent to fit with the existing codebase.