### PR TITLE
Implement TDD feature

### DIFF
--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		BBE490DA1FB2C643003D41BB /* InjectionError.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = InjectionError.tif; sourceTree = "<group>"; };
 		BBEB704A1FD28C6F00127711 /* XcodeHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XcodeHash.h; sourceTree = "<group>"; };
 		BBEB704B1FD28C6F00127711 /* XcodeHash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XcodeHash.m; sourceTree = "<group>"; };
+		BDB6A7CE21824C800001CF95 /* UserDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserDefaults.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -350,6 +351,7 @@
 				BBCA02581FB112F500E45F0F /* App.icns */,
 				BBCA02091FB0F10400E45F0F /* main.m */,
 				BBCA020B1FB0F10400E45F0F /* InjectionIII.entitlements */,
+				BDB6A7CE21824C800001CF95 /* UserDefaults.h */,
 			);
 			path = InjectionIII;
 			sourceTree = "<group>";

--- a/InjectionIII/AppDelegate.mm
+++ b/InjectionIII/AppDelegate.mm
@@ -18,6 +18,7 @@
 //#import "DDHotKeyCenter.h"
 
 #import "InjectionIII-Swift.h"
+#import "UserDefaults.h"
 
 #ifdef XPROBE_PORT
 #import "../XprobePlugin/Classes/XprobePluginMenuController.h"
@@ -32,7 +33,7 @@ AppDelegate *appDelegate;
 
 @implementation AppDelegate {
     IBOutlet NSMenu *statusMenu;
-    IBOutlet NSMenuItem *startItem, *xprobeItem, *windowItem;
+    IBOutlet NSMenuItem *startItem, *xprobeItem, *enabledTDDItem, *windowItem;
     IBOutlet NSStatusItem *statusItem;
 }
 
@@ -49,6 +50,10 @@ AppDelegate *appDelegate;
     statusItem.enabled = TRUE;
     statusItem.title = @"";
 
+    enabledTDDItem.state = ([[NSUserDefaults standardUserDefaults] boolForKey:UserDefaultsTDDEnabled])
+        ? NSControlStateValueOn
+        : NSControlStateValueOff;
+
     [self setMenuIcon:@"InjectionIdle"];
 #if 0
     [[DDHotKeyCenter sharedHotKeyCenter] registerHotKeyWithKeyCode:kVK_ANSI_Equal
@@ -59,6 +64,15 @@ AppDelegate *appDelegate;
 
 - (IBAction)openProject:sender {
     [self application:NSApp openFile:nil];
+}
+
+- (IBAction)toggleTDD:(NSMenuItem *)sender {
+    [self toggleState:sender];
+
+    BOOL newSetting = sender.state == NSControlStateValueOn;
+
+    [[NSUserDefaults standardUserDefaults] setBool:newSetting forKey:UserDefaultsTDDEnabled];
+    NSLog(@"sender: %ld", (long)[sender state]);
 }
 
 - (BOOL)application:(NSApplication *)theApplication openFile:(NSString *)filename {

--- a/InjectionIII/Base.lproj/MainMenu.xib
+++ b/InjectionIII/Base.lproj/MainMenu.xib
@@ -16,6 +16,7 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
                 <outlet property="enableWatcher" destination="0iA-WA-gxc" id="vVT-sI-q78"/>
+                <outlet property="enabledTDDItem" destination="cCv-GY-3Rv" id="gWc-O6-aDP"/>
                 <outlet property="startItem" destination="vsd-ll-3nr" id="ODN-wa-BTp"/>
                 <outlet property="statusMenu" destination="V8Q-mq-A2f" id="Epo-HD-J21"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
@@ -619,13 +620,13 @@
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
                             <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="toggleSourceList:" target="-1" id="iwa-gc-5KM"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                            <menuItem title="Enter Full Screen" keyEquivalent="↩" id="4J7-dP-txa">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="toggleFullScreen:" target="-1" id="dU3-MA-1Rq"/>
                                 </connections>
@@ -651,7 +652,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -688,6 +689,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleState:" target="Voe-Tx-rLC" id="old-T7-DMa"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Enable TDD" id="cCv-GY-3Rv">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleTDD:" target="Voe-Tx-rLC" id="tqU-Qb-3kf"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Run Xprobe" id="R6p-Yl-7qz">

--- a/InjectionIII/FileWatcher.h
+++ b/InjectionIII/FileWatcher.h
@@ -14,6 +14,7 @@ typedef void (^InjectionCallback)(NSArray *filesChanged);
 
 @interface FileWatcher : NSObject
 
+@property(retain, nonatomic) NSString *projectRoot;
 @property(copy) InjectionCallback callback;
 
 - (instancetype)initWithRoot:(NSString *)projectRoot plugin:(InjectionCallback)callback;

--- a/InjectionIII/FileWatcher.h
+++ b/InjectionIII/FileWatcher.h
@@ -14,7 +14,6 @@ typedef void (^InjectionCallback)(NSArray *filesChanged);
 
 @interface FileWatcher : NSObject
 
-@property(retain, nonatomic) NSString *projectRoot;
 @property(copy) InjectionCallback callback;
 
 - (instancetype)initWithRoot:(NSString *)projectRoot plugin:(InjectionCallback)callback;

--- a/InjectionIII/FileWatcher.m
+++ b/InjectionIII/FileWatcher.m
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 John Holdsworth. All rights reserved.
 //
 
-#import "UserDefaults.h"
 #import "FileWatcher.h"
 
 @implementation FileWatcher {
@@ -40,7 +39,6 @@ static void fileCallback(ConstFSEventStreamRef streamRef,
 - (instancetype)initWithRoot:(NSString *)projectRoot plugin:(InjectionCallback)callback;
 {
     if ((self = [super init])) {
-        self.projectRoot = projectRoot;
         self.callback = callback;
         static struct FSEventStreamContext context;
         context.info = (__bridge void *)self;
@@ -70,57 +68,12 @@ static void fileCallback(ConstFSEventStreamRef streamRef,
             [fileManager fileExistsAtPath:path]) {
 
             [changed addObject:path];
-
-            if ([[NSUserDefaults standardUserDefaults] boolForKey:UserDefaultsTDDEnabled]) {
-                NSArray *matchedTests = [self searchForTestWithFile:path projectRoot:self.projectRoot fileManager:fileManager];
-                [changed addObjectsFromArray:matchedTests];
-            }
         }
     }
 
     //NSLog( @"filesChanged: %@", changed );
     if (changed.count)
         self.callback([[changed objectEnumerator] allObjects]);
-}
-
-- (NSArray *)searchForTestWithFile:(NSString *)injectedFile projectRoot:(NSString *)projectRoot fileManager:(NSFileManager *)fileManager;
-{
-    NSString *injectedFileName = [[injectedFile lastPathComponent] stringByDeletingPathExtension];
-    NSURL *projectUrl = [NSURL URLWithString:projectRoot];
-    NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtURL:projectUrl
-                                          includingPropertiesForKeys:@[NSURLNameKey, NSURLIsDirectoryKey]
-                                                             options:NSDirectoryEnumerationSkipsHiddenFiles
-                                                        errorHandler:^BOOL(NSURL *url, NSError *error)
-                                         {
-                                             if (error) {
-                                                 NSLog(@"[Error] %@ (%@)", error, url);
-                                                 return NO;
-                                             }
-
-                                             return YES;
-                                         }];
-
-    NSMutableArray *matchedTests = [NSMutableArray array];
-    for (NSURL *fileURL in enumerator) {
-        NSString *filename;
-        NSNumber *isDirectory;
-
-        [fileURL getResourceValue:&filename forKey:NSURLNameKey error:nil];
-        [fileURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
-
-        if ([filename hasPrefix:@"_"] && [isDirectory boolValue]) {
-            [enumerator skipDescendants];
-            continue;
-        }
-
-        if (![isDirectory boolValue] &&
-            ![[filename lastPathComponent] isEqualToString:[injectedFile lastPathComponent]] &&
-            [[filename lowercaseString] containsString:[injectedFileName lowercaseString]]) {
-            [matchedTests addObject:fileURL.path];
-        }
-    }
-
-    return matchedTests;
 }
 
 - (void)dealloc;

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.2</string>
 	<key>CFBundleVersion</key>
-	<string>1199</string>
+	<string>1268</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.2</string>
 	<key>CFBundleVersion</key>
-	<string>1268</string>
+	<string>1287</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/UserDefaults.h
+++ b/InjectionIII/UserDefaults.h
@@ -1,0 +1,11 @@
+//
+//  UserDefaults.h
+//  InjectionIII
+//
+//  Created by Christoffer Winterkvist on 10/25/18.
+//  Copyright © 2018 John Holdsworth. All rights reserved.
+//
+
+#import "AppDelegate.h"
+
+NSString *const UserDefaultsTDDEnabled = @"Enabled TDD";


### PR DESCRIPTION
Adds a new menu item to enable TDD.

When TDD is enabled, the file watcher will search the project root directory for a corresponding test case for the file that was injected. If a match is found, it will run the tests for that file after it has been injected.

Files are matched using file name using ```containsString:```

The feature is an opt-in feature which means that it is disabled by default. It is enabled or disabled using the applications menu icon.

### Screenshot

<img width="178" alt="image" src="https://user-images.githubusercontent.com/57446/47525135-cb2caa80-d89c-11e8-89ba-24ee82931ed4.png">
