### PR TITLE
URL encode projectRoot

### DIFF
--- a/InjectionIII/InjectionServer.mm
+++ b/InjectionIII/InjectionServer.mm
@@ -229,7 +229,7 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
 {
     NSMutableArray *matchedTests = [NSMutableArray array];
     NSString *injectedFileName = [[injectedFile lastPathComponent] stringByDeletingPathExtension];
-    NSURL *projectUrl = [NSURL URLWithString:projectRoot];
+    NSURL *projectUrl = [NSURL URLWithString:[self urlEncodeString:projectRoot]];
     NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtURL:projectUrl
                                           includingPropertiesForKeys:@[NSURLNameKey, NSURLIsDirectoryKey]
                                                              options:NSDirectoryEnumerationSkipsHiddenFiles
@@ -264,6 +264,13 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
     }
 
     return matchedTests;
+}
+
++ (nullable NSString *)urlEncodeString:(NSString *)string {
+    NSString *unreserved = @"-._~/?";
+    NSMutableCharacterSet *allowed = [NSMutableCharacterSet alphanumericCharacterSet];
+    [allowed addCharactersInString:unreserved];
+    return [string stringByAddingPercentEncodingWithAllowedCharacters: allowed];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
This fixes an exception being thrown if the project has spaces in it and the TDD feature is enabled.
Project names need to be properly url encoded before InjectionIII tries to use it. Now the projectRoot
is url encoded using a static method on InjectionServer, it fixes the issue with an exception being
thrown if a URL cannot be created using the current project root.