### PR TITLE
Improve precision of regular expression when injecting storyboards

### DIFF
--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -220,7 +220,7 @@ public class SwiftEval: NSObject {
                         if ($line =~ /^\\s*cd /) {
                             $realPath = $line;
                         }
-                        elsif (my ($product) = $line =~ m@\\.xcent --timestamp=none (.*)\\r@o) {
+                        elsif (my ($product) = $line =~ m@\\.xcent --timestamp=none (.*\\.app)\\r@o) {
                             print $product;
                             exit 0;
                         }


### PR DESCRIPTION
This improves the regular expression by specifically looking for `.app` instead of
anything that matches. This helps avoid mismatching when the main application
has app extensions.