### PR TITLE
Improve/print statements

### DIFF
--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -104,7 +104,7 @@ static struct {
     if (InjectionClient *client = [self connectTo:INJECTION_ADDRESS])
         [client run];
     else
-        printf("Injection loaded but could not connect. Is InjectionIII.app running?\n");
+        printf("💉 Injection loaded but could not connect. Is InjectionIII.app running?\n");
 
 }
 

--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -140,7 +140,7 @@ static struct {
             NSString *projectFile = [self readString];
             [SwiftEval sharedInstance].projectFile = projectFile;
             [SwiftEval sharedInstance].derivedLogs = nil;
-            printf("Injection connected, watching %s/**\n",
+            printf("💉 Injection connected, watching %s/**\n",
                    projectFile.stringByDeletingLastPathComponent.UTF8String);
             break;
         }

--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -367,11 +367,10 @@ public class SwiftEval: NSObject {
     @objc func loadAndInject(tmpfile: String, oldClass: AnyClass? = nil) throws -> [AnyClass] {
 
         // load patched .dylib into process with new version of class
-
-        print("Loading .dylib - Ignore any duplicate class warning...")
         guard let dl = dlopen("\(tmpfile).dylib", RTLD_NOW) else {
             throw evalError("dlopen() error: \(String(cString: dlerror()))")
         }
+        print("💉 Loaded .dylib - Ignore any duplicate class warning...")
 
         if oldClass != nil {
             // find patched version of class using symbol for existing

--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -158,7 +158,7 @@ public class SwiftEval: NSObject {
     /// Error handler
     @objc public var evalError = {
         (_ message: String) -> Error in
-        print("*** \(message) ***")
+        print("💉 *** \(message) ***")
         return NSError(domain: "SwiftEval", code: -1, userInfo: [NSLocalizedDescriptionKey: message])
     }
 

--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -366,6 +366,7 @@ public class SwiftEval: NSObject {
 
     @objc func loadAndInject(tmpfile: String, oldClass: AnyClass? = nil) throws -> [AnyClass] {
 
+        print("💉 Loading .dylib - Ignore any duplicate class warning...")
         // load patched .dylib into process with new version of class
         guard let dl = dlopen("\(tmpfile).dylib", RTLD_NOW) else {
             throw evalError("dlopen() error: \(String(cString: dlerror()))")

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -115,7 +115,7 @@ public class SwiftInjection: NSObject {
             // Swift equivalent of Swizzling
             if (classMetadata.pointee.Data & 0x1) == 1 {
                 if classMetadata.pointee.ClassSize != existingClass.pointee.ClassSize {
-                    NSLog("\(oldClass) metadata size changed. Did you add a method?")
+                    NSLog("💉 \(oldClass) metadata size changed. Did you add a method?")
                 }
 
                 func byteAddr<T>(_ location: UnsafeMutablePointer<T>) -> UnsafeMutablePointer<UInt8> {
@@ -126,7 +126,7 @@ public class SwiftInjection: NSObject {
                 let vtableLength = Int(existingClass.pointee.ClassSize -
                     existingClass.pointee.ClassAddressPoint) - vtableOffset
 
-                print("Injected '\(NSStringFromClass(oldClass))'")
+                print("💉 Injected '\(NSStringFromClass(oldClass))'")
                 memcpy(byteAddr(existingClass) + vtableOffset,
                        byteAddr(classMetadata) + vtableOffset, vtableLength)
             }


### PR DESCRIPTION
- Print statements now use 💉 as a prefix. This is done to help the user understand where the message comes from.
- The instruction that the duplicate class warnings should be ignored often get overlooked by the users. The print statement has now been moved to help discoverability of the message. It also uses the same 💉 as the rest of the print messages.