### PR TITLE
Feature Vaccine

### DIFF
--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -136,7 +136,7 @@ static struct {
     InjectionCommand command;
     while ((command = (InjectionCommand)[self readInt]) != InjectionEOF) {
         switch (command) {
-        case InjectionUserDefaultsChanged: {
+        case InjectionVaccineSettingChanged: {
             NSString *string = [self readString];
             NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
             id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];

--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -136,6 +136,18 @@ static struct {
     InjectionCommand command;
     while ((command = (InjectionCommand)[self readInt]) != InjectionEOF) {
         switch (command) {
+        case InjectionUserDefaultsChanged: {
+            NSString *string = [self readString];
+            NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+            id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+
+            NSDictionary *dictionary = (NSDictionary *)json;
+            if (dictionary != nil) {
+                NSNumber *vaccineEnabled = [dictionary valueForKey:@"Enabled Vaccine"];
+                [SwiftEval sharedInstance].vaccineEnabled = [vaccineEnabled boolValue];
+            }
+            break;
+        }
         case InjectionProject: {
             NSString *projectFile = [self readString];
             [SwiftEval sharedInstance].projectFile = projectFile;

--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -138,6 +138,7 @@ public class SwiftEval: NSObject {
     }
 
     @objc public var signer: ((_: String) -> Bool)?
+    @objc public var vaccineEnabled: Bool = false
 
     // client specific info
     @objc public var frameworks = Bundle.main.privateFrameworksPath

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -187,7 +187,7 @@ public class SwiftInjection: NSObject {
                                 flash(vc: vc)
                             }
                             #endif
-                        } else {
+                        } else if SwiftEval.sharedInstance().vaccineEnabled {
                             let vaccine = Vaccine()
                             vaccine.performInjection(on: instance)
                         }

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -179,23 +179,20 @@ public class SwiftInjection: NSObject {
                     (instance: AnyObject) in
                     if injectedClasses.contains(where: { $0 == object_getClass(instance) }) {
                         let proto = unsafeBitCast(instance, to: SwiftInjected.self)
-
-                        if instance.responds(to: _Selector("injected")) == true {
-                            if SwiftEval.sharedInstance().vaccineEnabled {
-                                let vaccine = Vaccine()
-                                vaccine.performInjection(on: instance)
-                                proto.injected?()
-                                return
-                            }
-
+                        if SwiftEval.sharedInstance().vaccineEnabled {
+                            let vaccine = Vaccine()
+                            vaccine.performInjection(on: instance)
                             proto.injected?()
-
-                            #if os(iOS) || os(tvOS)
-                            if let vc = instance as? UIViewController {
-                                flash(vc: vc)
-                            }
-                            #endif
+                            return
                         }
+
+                        proto.injected?()
+
+                        #if os(iOS) || os(tvOS)
+                        if let vc = instance as? UIViewController {
+                            flash(vc: vc)
+                        }
+                        #endif
                     }
                 }).sweepValue(seeds)
             }

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -158,13 +158,13 @@ public class SwiftInjection: NSObject {
         } else {
             var injectedClasses = [AnyClass]()
             for cls in oldClasses {
-                //if class_getInstanceMethod(cls, #selector(SwiftInjected.injected)) != nil {
+                if class_getInstanceMethod(cls, #selector(SwiftInjected.injected)) != nil {
                     injectedClasses.append(cls)
                     let kvoName = "NSKVONotifying_" + NSStringFromClass(cls)
                     if let kvoCls = NSClassFromString(kvoName) {
                         injectedClasses.append(kvoCls)
                     }
-                //}
+                }
             }
 
             // implement -injected() method using sweep of objects in application
@@ -181,15 +181,20 @@ public class SwiftInjection: NSObject {
                         let proto = unsafeBitCast(instance, to: SwiftInjected.self)
 
                         if instance.responds(to: _Selector("injected")) == true {
+                            if SwiftEval.sharedInstance().vaccineEnabled {
+                                let vaccine = Vaccine()
+                                vaccine.performInjection(on: instance)
+                                proto.injected?()
+                                return
+                            }
+
                             proto.injected?()
+
                             #if os(iOS) || os(tvOS)
                             if let vc = instance as? UIViewController {
                                 flash(vc: vc)
                             }
                             #endif
-                        } else if SwiftEval.sharedInstance().vaccineEnabled {
-                            let vaccine = Vaccine()
-                            vaccine.performInjection(on: instance)
                         }
                     }
                 }).sweepValue(seeds)

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -202,10 +202,6 @@ public class SwiftInjection: NSObject {
         }
     }
 
-    public class func _Selector(_ string: String) -> Selector {
-        return Selector(string)
-    }
-
     #if os(iOS) || os(tvOS)
     @objc(flash:)
     public class func flash(vc: UIViewController) {

--- a/InjectionBundle/Vaccine.swift
+++ b/InjectionBundle/Vaccine.swift
@@ -1,0 +1,145 @@
+#if os(macOS)
+import Cocoa
+typealias View = NSView
+typealias ViewController = NSViewController
+typealias ScrollView = NSScrollView
+#else
+import UIKit
+typealias View = UIView
+typealias ViewController = UIViewController
+typealias ScrollView = UIScrollView
+
+fileprivate extension ViewController {
+    func viewWillAppear() { self.viewWillAppear(false) }
+    func viewDidAppear() { self.viewDidAppear(false) }
+}
+#endif
+
+extension View {
+    func subviewsRecursive() -> [View] {
+        return subviews + subviews.flatMap { $0.subviewsRecursive() }
+    }
+}
+
+class Vaccine {
+    func performInjection(on object: AnyObject) {
+        CATransaction.begin()
+        CATransaction.lock()
+        switch object {
+        case let viewController as ViewController:
+            let oldScrollViews = indexScrollViews(on: viewController)
+            reload(viewController.parent ?? viewController)
+            syncOldScrollViews(oldScrollViews, with: indexScrollViews(on: viewController))
+        case let view as View:
+            reload(view)
+        default:
+            break
+        }
+        let nearFuture = DispatchTime.now() + 0.3
+        DispatchQueue.main.asyncAfter(deadline: nearFuture) {
+            CATransaction.unlock()
+            CATransaction.commit()
+        }
+    }
+
+    private func reload(_ viewController: ViewController) {
+        viewController.view.subviews.forEach { $0.removeFromSuperview() }
+        clean(view: viewController.view)
+        viewController.loadView()
+        viewController.viewDidLoad()
+        viewController.viewWillAppear()
+        viewController.viewDidAppear()
+        refreshSubviews(on: viewController.view)
+    }
+
+    private func reload(_ view: View) {
+        let selector = _Selector("loadView")
+        guard view.responds(to: selector) == true else { return }
+
+        #if os(macOS)
+        view.animator().perform(selector)
+        #else
+            UIView.animate(withDuration: 0.3, delay: 0.0, options: [.allowAnimatedContent,
+                                                                  .beginFromCurrentState,
+                                                                  .layoutSubviews], animations: {
+            view.perform(selector)
+        }, completion: nil)
+        #endif
+    }
+
+    private func clean(view: View) {
+        view.subviews.forEach { $0.removeFromSuperview() }
+
+        #if os(macOS)
+        if let sublayers = view.layer?.sublayers {
+            sublayers.forEach { $0.removeFromSuperlayer() }
+        }
+        #else
+        if let sublayers = view.layer.sublayers {
+            sublayers.forEach { $0.removeFromSuperlayer() }
+        }
+        #endif
+    }
+
+    private func refreshSubviews(on view: View) {
+        #if os(macOS)
+        view.subviewsRecursive().forEach { view in
+            (view as? NSTableView)?.reloadData()
+            (view as? NSCollectionView)?.reloadData()
+            view.needsLayout = true
+            view.layout()
+            view.needsDisplay = true
+            view.display()
+        }
+        #else
+        view.subviewsRecursive().forEach { view in
+            (view as? UITableView)?.reloadData()
+            (view as? UICollectionView)?.reloadData()
+            view.setNeedsLayout()
+            view.layoutIfNeeded()
+            view.setNeedsDisplay()
+        }
+        #endif
+    }
+
+    private func indexScrollViews(on viewController: ViewController) -> [ScrollView] {
+        var scrollViews = [ScrollView]()
+
+        for case let scrollView as ScrollView in viewController.view.subviews {
+            scrollViews.append(scrollView)
+        }
+
+        if let parentViewController = viewController.parent {
+            for case let scrollView as ScrollView in parentViewController.view.subviews {
+                scrollViews.append(scrollView)
+            }
+        }
+
+        for childViewController in viewController.childViewControllers {
+            for case let scrollView as ScrollView in childViewController.view.subviews {
+                scrollViews.append(scrollView)
+            }
+        }
+
+        return scrollViews
+    }
+
+    private func syncOldScrollViews(_ oldScrollViews: [ScrollView], with newScrollViews: [ScrollView]) {
+        for (offset, scrollView) in newScrollViews.enumerated() {
+            if offset < oldScrollViews.count {
+                let oldScrollView = oldScrollViews[offset]
+                if type(of: scrollView) == type(of: oldScrollView) {
+                    #if os(macOS)
+                    scrollView.contentView.scroll(to: oldScrollView.documentVisibleRect.origin)
+                    #else
+                    scrollView.contentOffset = oldScrollView.contentOffset
+                    #endif
+                }
+            }
+        }
+    }
+
+    private func _Selector(_ string: String) -> Selector {
+        return Selector(string)
+    }
+}

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		BBE490DB1FB2C643003D41BB /* InjectionBusy.tif in Resources */ = {isa = PBXBuildFile; fileRef = BBE490D91FB2C643003D41BB /* InjectionBusy.tif */; };
 		BBE490DC1FB2C643003D41BB /* InjectionError.tif in Resources */ = {isa = PBXBuildFile; fileRef = BBE490DA1FB2C643003D41BB /* InjectionError.tif */; };
 		BBEB704C1FD28C6F00127711 /* XcodeHash.m in Sources */ = {isa = PBXBuildFile; fileRef = BBEB704B1FD28C6F00127711 /* XcodeHash.m */; };
+		BD35949E21A6C5DE0020EB94 /* Vaccine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD35949D21A6C5DE0020EB94 /* Vaccine.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,6 +169,7 @@
 		BBE490DA1FB2C643003D41BB /* InjectionError.tif */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = InjectionError.tif; sourceTree = "<group>"; };
 		BBEB704A1FD28C6F00127711 /* XcodeHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XcodeHash.h; sourceTree = "<group>"; };
 		BBEB704B1FD28C6F00127711 /* XcodeHash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XcodeHash.m; sourceTree = "<group>"; };
+		BD35949D21A6C5DE0020EB94 /* Vaccine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vaccine.swift; sourceTree = "<group>"; };
 		BDB6A7CE21824C800001CF95 /* UserDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserDefaults.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -367,6 +369,7 @@
 				BB439B8A1FABA65D00B4F50B /* SwiftEval.swift */,
 				BB109FAF1FAECD92008C5218 /* SwiftInjection.swift */,
 				BBB64FE41FD576AA0020BE47 /* XprobeSwift-Bridging-Header.h */,
+				BD35949D21A6C5DE0020EB94 /* Vaccine.swift */,
 			);
 			path = InjectionBundle;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BBCA02501FB107AF00E45F0F /* SwiftEval.swift in Sources */,
+				BD35949E21A6C5DE0020EB94 /* Vaccine.swift in Sources */,
 				BBCA02511FB107AF00E45F0F /* SwiftInjection.swift in Sources */,
 				BBB64FE11FD575260020BE47 /* XprobeSwift.swift in Sources */,
 				BBB64FE61FD577EB0020BE47 /* SwiftSwizzler.swift in Sources */,

--- a/InjectionIII/AppDelegate.h
+++ b/InjectionIII/AppDelegate.h
@@ -15,6 +15,7 @@
 @property (weak) InjectionServer *lastConnection;
 @property NSString *selectedProject;
 
+- (NSString *)vaccineConfiguration;
 - (void)setMenuIcon:(NSString *)tiffName;
 - (IBAction)openProject:sender;
 

--- a/InjectionIII/AppDelegate.mm
+++ b/InjectionIII/AppDelegate.mm
@@ -33,7 +33,7 @@ AppDelegate *appDelegate;
 
 @implementation AppDelegate {
     IBOutlet NSMenu *statusMenu;
-    IBOutlet NSMenuItem *startItem, *xprobeItem, *enabledTDDItem, *enableVaccine, *windowItem;
+    IBOutlet NSMenuItem *startItem, *xprobeItem, *enabledTDDItem, *enableVaccineItem, *windowItem;
     IBOutlet NSStatusItem *statusItem;
 }
 
@@ -50,7 +50,10 @@ AppDelegate *appDelegate;
     statusItem.enabled = TRUE;
     statusItem.title = @"";
 
-    enabledTDDItem.state = ([[NSUserDefaults standardUserDefaults] boolForKey:UserDefaultsTDDEnabled])
+    enabledTDDItem.state = ([[NSUserDefaults standardUserDefaults] boolForKey:UserDefaultsTDDEnabled] == YES)
+        ? NSControlStateValueOn
+        : NSControlStateValueOff;
+    enableVaccineItem.state = ([[NSUserDefaults standardUserDefaults] boolForKey:UserDefaultsVaccineEnabled] == YES)
         ? NSControlStateValueOn
         : NSControlStateValueOff;
 
@@ -74,16 +77,20 @@ AppDelegate *appDelegate;
     [self toggleState:sender];
     BOOL newSetting = sender.state == NSControlStateValueOn;
     [[NSUserDefaults standardUserDefaults] setBool:newSetting forKey:UserDefaultsVaccineEnabled];
+    [self.lastConnection writeCommand:InjectionVaccineSettingChanged withString:[appDelegate vaccineConfiguration]];
+}
 
-    NSNumber *value = [NSNumber numberWithBool:newSetting];
+- (NSString *)vaccineConfiguration {
+    BOOL vaccineSetting = [[NSUserDefaults standardUserDefaults] boolForKey:UserDefaultsVaccineEnabled];
+    NSNumber *value = [NSNumber numberWithBool:vaccineSetting];
     NSString *key = [NSString stringWithString:UserDefaultsVaccineEnabled];
     NSDictionary *dictionary = [NSDictionary dictionaryWithObjects:@[value] forKeys:@[key]];
     NSError *err;
     NSData *jsonData = [NSJSONSerialization  dataWithJSONObject:dictionary
-                                                         options:0
-                                                           error:&err];
-    NSString *userDefaults = [[NSString alloc] initWithData:jsonData   encoding:NSUTF8StringEncoding];
-    [self.lastConnection writeCommand:InjectionUserDefaultsChanged withString:userDefaults];
+                                                        options:0
+                                                          error:&err];
+    NSString *configuration = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    return configuration;
 }
 
 - (BOOL)application:(NSApplication *)theApplication openFile:(NSString *)filename {

--- a/InjectionIII/AppDelegate.mm
+++ b/InjectionIII/AppDelegate.mm
@@ -33,7 +33,7 @@ AppDelegate *appDelegate;
 
 @implementation AppDelegate {
     IBOutlet NSMenu *statusMenu;
-    IBOutlet NSMenuItem *startItem, *xprobeItem, *enabledTDDItem, *windowItem;
+    IBOutlet NSMenuItem *startItem, *xprobeItem, *enabledTDDItem, *enableVaccine, *windowItem;
     IBOutlet NSStatusItem *statusItem;
 }
 
@@ -66,11 +66,24 @@ AppDelegate *appDelegate;
 
 - (IBAction)toggleTDD:(NSMenuItem *)sender {
     [self toggleState:sender];
-
     BOOL newSetting = sender.state == NSControlStateValueOn;
-
     [[NSUserDefaults standardUserDefaults] setBool:newSetting forKey:UserDefaultsTDDEnabled];
-    NSLog(@"sender: %ld", (long)[sender state]);
+}
+
+- (IBAction)toggleVaccine:(NSMenuItem *)sender {
+    [self toggleState:sender];
+    BOOL newSetting = sender.state == NSControlStateValueOn;
+    [[NSUserDefaults standardUserDefaults] setBool:newSetting forKey:UserDefaultsVaccineEnabled];
+
+    NSNumber *value = [NSNumber numberWithBool:newSetting];
+    NSString *key = [NSString stringWithString:UserDefaultsVaccineEnabled];
+    NSDictionary *dictionary = [NSDictionary dictionaryWithObjects:@[value] forKeys:@[key]];
+    NSError *err;
+    NSData *jsonData = [NSJSONSerialization  dataWithJSONObject:dictionary
+                                                         options:0
+                                                           error:&err];
+    NSString *userDefaults = [[NSString alloc] initWithData:jsonData   encoding:NSUTF8StringEncoding];
+    [self.lastConnection writeCommand:InjectionUserDefaultsChanged withString:userDefaults];
 }
 
 - (BOOL)application:(NSApplication *)theApplication openFile:(NSString *)filename {

--- a/InjectionIII/Base.lproj/MainMenu.xib
+++ b/InjectionIII/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +16,7 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
                 <outlet property="enableWatcher" destination="0iA-WA-gxc" id="vVT-sI-q78"/>
-                <outlet property="enabledTDDItem" destination="cCv-GY-3Rv" id="gWc-O6-aDP"/>
+                <outlet property="enabledTDDItem" destination="cCv-GY-3Rv" id="OES-hx-lAq"/>
                 <outlet property="startItem" destination="vsd-ll-3nr" id="ODN-wa-BTp"/>
                 <outlet property="statusMenu" destination="V8Q-mq-A2f" id="Epo-HD-J21"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
@@ -652,7 +652,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -691,10 +691,16 @@
                         <action selector="toggleState:" target="Voe-Tx-rLC" id="old-T7-DMa"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Enable TDD" id="cCv-GY-3Rv">
+                <menuItem title="Enable Vaccine" id="cCv-GY-3Rv" userLabel="Enabled Vaccine">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="toggleTDD:" target="Voe-Tx-rLC" id="tqU-Qb-3kf"/>
+                        <action selector="toggleVaccine:" target="Voe-Tx-rLC" id="6d6-vp-FLr"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Enable TDD" id="Mdd-tb-kGc">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleTDD:" target="Voe-Tx-rLC" id="hjO-wo-Oy4"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Run Xprobe" id="R6p-Yl-7qz">

--- a/InjectionIII/Base.lproj/MainMenu.xib
+++ b/InjectionIII/Base.lproj/MainMenu.xib
@@ -15,8 +15,9 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
+                <outlet property="enableVaccineItem" destination="cCv-GY-3Rv" id="Joe-DQ-AWO"/>
                 <outlet property="enableWatcher" destination="0iA-WA-gxc" id="vVT-sI-q78"/>
-                <outlet property="enabledTDDItem" destination="cCv-GY-3Rv" id="OES-hx-lAq"/>
+                <outlet property="enabledTDDItem" destination="Mdd-tb-kGc" id="ccs-nb-DKk"/>
                 <outlet property="startItem" destination="vsd-ll-3nr" id="ODN-wa-BTp"/>
                 <outlet property="statusMenu" destination="V8Q-mq-A2f" id="Epo-HD-J21"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3</string>
 	<key>CFBundleVersion</key>
-	<string>1439</string>
+	<string>1496</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3</string>
 	<key>CFBundleVersion</key>
-	<string>1383</string>
+	<string>1439</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/InjectionServer.h
+++ b/InjectionIII/InjectionServer.h
@@ -33,7 +33,7 @@ typedef NS_ENUM(int, InjectionCommand) {
     InjectionInject,
     InjectionXprobe,
     InjectionEval,
-    InjectionUserDefaultsChanged,
+    InjectionVaccineSettingChanged,
 
     InjectionEOF = ~0
 };

--- a/InjectionIII/InjectionServer.h
+++ b/InjectionIII/InjectionServer.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(int, InjectionCommand) {
     InjectionInject,
     InjectionXprobe,
     InjectionEval,
+    InjectionUserDefaultsChanged,
 
     InjectionEOF = ~0
 };

--- a/InjectionIII/InjectionServer.mm
+++ b/InjectionIII/InjectionServer.mm
@@ -240,6 +240,7 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
 - (void)setProject:(NSString *)project {
     if (!injector) return;
     [self writeCommand:InjectionProject withString:project];
+    [self writeCommand:InjectionVaccineSettingChanged withString:[appDelegate vaccineConfiguration]];
     fileWatcher = [[FileWatcher alloc]
                    initWithRoot:project.stringByDeletingLastPathComponent
                    plugin:injector];

--- a/InjectionIII/UserDefaults.h
+++ b/InjectionIII/UserDefaults.h
@@ -9,3 +9,4 @@
 #import "AppDelegate.h"
 
 NSString *const UserDefaultsTDDEnabled = @"Enabled TDD";
+NSString *const UserDefaultsVaccineEnabled = @"Enabled Vaccine";


### PR DESCRIPTION
I have this idea of deprecating `Vaccine` as a framework and ship the implementation together with `Injection`. Vaccine will be an opt-in feature that will be enabled and disabled in the same way as you enable TDD.

If you have the implementation enabled and your class does not respond to `injected`, it will fall back to running `Vaccine` in order to rebuild the view controllers or views state.

I've tested this implementation on iOS and tvOS and it works as the Vaccine framework does.

The biggest change to the client-server implementation is that a message is sent to the client notifying it of the current vaccine preference setting.