### PR TITLE
Use Vaccine (if enabled) when injecting storyboards/xibs

### DIFF
--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -273,13 +273,18 @@ static struct {
 
         [visibleVC _loadViewFromNibNamed:visibleVC.nibName
                                   bundle:visibleVC.nibBundle];
-        [visibleVC viewDidLoad];
-        [visibleVC viewWillAppear:NO];
-        [visibleVC viewDidAppear:NO];
+
+        if ([SwiftEval sharedInstance].vaccineEnabled == YES) {
+            [SwiftInjection vaccine:visibleVC];
+        } else {
+            [visibleVC viewDidLoad];
+            [visibleVC viewWillAppear:NO];
+            [visibleVC viewDidAppear:NO];
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-        [SwiftInjection flash:visibleVC];
+            [SwiftInjection flash:visibleVC];
 #endif
+        }
     }
     @catch(NSException *e) {
         printf("Problem reloading nib: %s\n", e.reason.UTF8String);

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -180,8 +180,7 @@ public class SwiftInjection: NSObject {
                     if injectedClasses.contains(where: { $0 == object_getClass(instance) }) {
                         let proto = unsafeBitCast(instance, to: SwiftInjected.self)
                         if SwiftEval.sharedInstance().vaccineEnabled {
-                            let vaccine = Vaccine()
-                            vaccine.performInjection(on: instance)
+                            performVaccineInjection(instance)
                             proto.injected?()
                             return
                         }
@@ -200,6 +199,12 @@ public class SwiftInjection: NSObject {
             let notification = Notification.Name("INJECTION_BUNDLE_NOTIFICATION")
             NotificationCenter.default.post(name: notification, object: oldClasses)
         }
+    }
+
+    @objc(vaccine:)
+    public class func performVaccineInjection(_ object: AnyObject) {
+        let vaccine = Vaccine()
+        vaccine.performInjection(on: object)
     }
 
     #if os(iOS) || os(tvOS)

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.3</string>
 	<key>CFBundleVersion</key>
-	<string>1496</string>
+	<string>1515</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Vaccine will be used when injecting storyboards and xibs. If Vaccine is disabled, the default behavior would remain the same as before the PR.