### PR TITLE
Improve handling of view controller injection in Vaccine

### DIFF
--- a/InjectionBundle/Vaccine.swift
+++ b/InjectionBundle/Vaccine.swift
@@ -124,7 +124,7 @@ class Vaccine {
                                      .beginFromCurrentState,
                                      .layoutSubviews],
                            animations: {
-                            snapshotView.alpha = 0.5
+                            snapshotView.alpha = 0.0
             }) { _ in
                 snapshotView.removeFromSuperview()
             }

--- a/InjectionBundle/Vaccine.swift
+++ b/InjectionBundle/Vaccine.swift
@@ -38,7 +38,7 @@ class Vaccine {
             #if os(macOS)
             reload(viewController.parent ?? viewController)
             #else
-            // Opt-out from performing Vaccine reloads in parent
+            // Opt-out from performing Vaccine reloads on parent
             // if the parent is either a navigation controller or
             // a tab bar controller.
             if let parentViewController = viewController.parent {

--- a/InjectionBundle/Vaccine.swift
+++ b/InjectionBundle/Vaccine.swift
@@ -118,7 +118,7 @@ class Vaccine {
                 snapshotView.removeFromSuperview()
             })
             #else
-            UIView.animate(withDuration: 1.0,
+            UIView.animate(withDuration: 0.25,
                            delay: 0.0,
                            options: [.allowAnimatedContent,
                                      .beginFromCurrentState,

--- a/InjectionBundle/Vaccine.swift
+++ b/InjectionBundle/Vaccine.swift
@@ -34,7 +34,26 @@ class Vaccine {
             }
 
             let oldScrollViews = indexScrollViews(on: viewController)
+
+            #if os(macOS)
             reload(viewController.parent ?? viewController)
+            #else
+            // Opt-out from performing Vaccine reloads in parent
+            // if the parent is either a navigation controller or
+            // a tab bar controller.
+            if let parentViewController = viewController.parent {
+              if parentViewController is UINavigationController {
+                reload(viewController)
+              } else if parentViewController is UITabBarController {
+                reload(viewController)
+              } else {
+                reload(parentViewController)
+              }
+            } else {
+              reload(viewController)
+            }
+            #endif
+
             syncOldScrollViews(oldScrollViews, with: indexScrollViews(on: viewController))
             cleanSnapshotViewIfNeeded(snapshotView, viewController: viewController)
         case let view as View:


### PR DESCRIPTION
When a view controller is injected and the parent view controller is either a navigation or tab bar controller, then inject the current view controller has the regular reload will not render the expected results for those scenarios.