### PR TITLE
Opt-out from trying to sweep classes that start with NS

### DIFF
--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -314,8 +314,13 @@ extension NSObject {
             if className.hasPrefix("_") {
                 return
             }
+
+            if className.starts(with: "NS") {
+                return
+            }
+
             #if os(OSX)
-            if className.starts(with: "NS") && cls != NSWindow.self {
+            if cls != NSWindow.self {
                 return
             }
             #endif

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -315,14 +315,12 @@ extension NSObject {
                 return
             }
 
-            if className.starts(with: "NS") {
-                return
-            }
-
             #if os(OSX)
-            if cls != NSWindow.self {
+            if className.starts(with: "NS") && cls != NSWindow.self {
                 return
             }
+            #else
+            if className.starts(with: "NS") { return }
             #endif
             if let ivars = class_copyIvarList(cls, &icnt) {
                 for i in 0 ..< Int(icnt) {

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -314,7 +314,6 @@ extension NSObject {
             if className.hasPrefix("_") {
                 return
             }
-
             #if os(OSX)
             if className.starts(with: "NS") && cls != NSWindow.self {
                 return


### PR DESCRIPTION
I'm a bit unsure about this fail-safe but it seems to do the trick.
I saw that we opt-out from sweeping classes that start with `NS` on macOS and what this does is simply apply it to all platforms. I ran into some crashes when the sweeper tried to invoke itself on classes like `NSLayoutConstraint`. From my testing, everything seems to be working as it should for my classes.