### PR TITLE
Add log message when chaning Swift classes

### DIFF
--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -118,6 +118,10 @@ public class SwiftInjection: NSObject {
             if (classMetadata.pointee.Data & 0x1) == 1 {
                 if classMetadata.pointee.ClassSize != existingClass.pointee.ClassSize {
                     NSLog("💉 \(oldClass) metadata size changed. Did you add a method?")
+
+                    if !(newClass.superclass() == NSObject.self) {
+                        NSLog("💉 ⚠️ Adding or removing functions on pure Swift classes is not supported. Your application will eventually crash. Inherit from NSObject while developing to avoid unexpected crashes. ⚠️")
+                    }
                 }
 
                 func byteAddr<T>(_ location: UnsafeMutablePointer<T>) -> UnsafeMutablePointer<UInt8> {

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -114,8 +114,9 @@ public class SwiftInjection: NSObject {
             let existingClass = unsafeBitCast(oldClass, to: UnsafeMutablePointer<ClassMetadataSwift>.self)
             let classMetadata = unsafeBitCast(newClass, to: UnsafeMutablePointer<ClassMetadataSwift>.self)
 
-            // Swift equivalent of Swizzling
+            // Is this a Swift class?
             if (classMetadata.pointee.Data & 0x1) == 1 {
+                // Swift equivalent of Swizzling
                 if classMetadata.pointee.ClassSize != existingClass.pointee.ClassSize {
                     NSLog("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
                 }

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -120,7 +120,7 @@ public class SwiftInjection: NSObject {
                     NSLog("💉 \(oldClass) metadata size changed. Did you add a method?")
 
                     if !(newClass.superclass() == NSObject.self) {
-                        NSLog("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
+                        print("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
                     }
                 }
 

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -120,7 +120,7 @@ public class SwiftInjection: NSObject {
                     NSLog("💉 \(oldClass) metadata size changed. Did you add a method?")
 
                     if !(newClass.superclass() == NSObject.self) {
-                        NSLog("💉 ⚠️ Adding or removing functions on pure Swift classes is not supported. Your application will eventually crash. Inherit from NSObject while developing to avoid unexpected crashes. ⚠️")
+                        NSLog("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
                     }
                 }
 

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -117,11 +117,7 @@ public class SwiftInjection: NSObject {
             // Swift equivalent of Swizzling
             if (classMetadata.pointee.Data & 0x1) == 1 {
                 if classMetadata.pointee.ClassSize != existingClass.pointee.ClassSize {
-                    NSLog("💉 \(oldClass) metadata size changed. Did you add a method?")
-
-                    if !(newClass.superclass() == NSObject.self) {
-                        print("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
-                    }
+                    NSLog("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
                 }
 
                 func byteAddr<T>(_ location: UnsafeMutablePointer<T>) -> UnsafeMutablePointer<UInt8> {


### PR DESCRIPTION
Adding and removing functions on Swift classes is not supported as it modifies the vtable. To solve the issue, inherit from NSObject, this is now described in the message that gets printed when this happens.