### PR TITLE
Cocoapod Support for iOS, MacOS and TVOS

### DIFF
--- a/InjectionBundle/CoreInjectionClient.h
+++ b/InjectionBundle/CoreInjectionClient.h
@@ -1,0 +1,17 @@
+//
+//  CoreInjectionClient.h
+//  InjectionBundle
+//
+//  Created by Francisco Javier Trujillo Mata on 23/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+#import "InjectionClient.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CoreInjectionClient : InjectionClient
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/InjectionBundle/CoreInjectionClient.mm
+++ b/InjectionBundle/CoreInjectionClient.mm
@@ -1,0 +1,60 @@
+//
+//  CoreInjectionClient.m
+//  InjectionBundle
+//
+//  Created by Francisco Javier Trujillo Mata on 23/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+#import "CoreInjectionClient.h"
+
+#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __has_include("tvOSInjection10-Swift.h")
+#import "tvOSInjection10-Swift.h"
+#elif __has_include("tvOSInjection-Swift.h")
+#import "tvOSInjection-Swift.h"
+#elif __has_include("iOSInjection10-Swift.h")
+#import "iOSInjection10-Swift.h"
+#else
+
+#if __has_include("iOSInjection-Swift.h")
+#import "iOSInjection-Swift.h"
+#elif __has_include("InjectionIII/InjectionIII-Swift.h")
+#import "InjectionIII/InjectionIII-Swift.h"
+#endif
+
+#endif
+
+#else
+
+#if __has_include("macOSInjection10-Swift.h")
+#import "macOSInjection10-Swift.h"
+#else
+
+#if __has_include("macOSInjection-Swift.h")
+#import "macOSInjection-Swift.h"
+#elif __has_include("InjectionIII/InjectionIII-Swift.h")
+#import "InjectionIII/InjectionIII-Swift.h"
+#endif
+
+#endif
+#endif
+
+
+@implementation CoreInjectionClient
+
++ (void)load {
+    [self createInjectionClient];
+}
+
+- (SwiftInjection *)swiftInjection
+{
+    static SwiftInjection *_swiftInjection;
+    if (!_swiftInjection) {
+        _swiftInjection = [[SwiftInjection alloc] init];
+    }
+    
+    return _swiftInjection;
+}
+
+@end

--- a/InjectionBundle/InjectionClient.h
+++ b/InjectionBundle/InjectionClient.h
@@ -8,6 +8,12 @@
 
 #import "SimpleSocket.h"
 
+@class SwiftInjection;
+
 @interface InjectionClient : SimpleSocket
+
+@property (nonatomic, strong, readonly) SwiftInjection *swiftInjection;
+
++ (void)createInjectionClient;
 
 @end

--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -7,7 +7,7 @@
 //
 
 #import "InjectionClient.h"
-#import "InjectionServer.h"
+#import "InjectionEnum.h"
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
 #if __has_include("tvOSInjection10-Swift.h")
@@ -17,9 +17,17 @@
 #elif __has_include("iOSInjection10-Swift.h")
 #import "iOSInjection10-Swift.h"
 #else
+
+#if __has_include("iOSInjection-Swift.h")
 #import "iOSInjection-Swift.h"
+#elif __has_include("InjectionIII/InjectionIII-Swift.h")
+#import "InjectionIII/InjectionIII-Swift.h"
 #endif
+
+#endif
+
 #import <UIKit/UIKit.h>
+#import <objc/runtime.h>
 
 @implementation NSObject (Remapper)
 

--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -113,13 +113,12 @@ static struct {
 
 @implementation InjectionClient
 
-+ (void)load {
-    // connect to InjetionIII.app using sicket
++ (void)createInjectionClient {
+    // connect to InjetionIII.app using socket
     if (InjectionClient *client = [self connectTo:INJECTION_ADDRESS])
         [client run];
     else
         printf("💉 Injection loaded but could not connect. Is InjectionIII.app running?\n");
-
 }
 
 - (void)runInBackground {
@@ -182,7 +181,7 @@ static struct {
                 NSError *err = nil;
                 switch (command) {
                 case InjectionLoad:
-                    [SwiftInjection injectWithTmpfile:changed error:&err];
+                    [self.swiftInjection injectWithTmpfile:changed error:&err];
                     break;
                 case InjectionInject: {
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
@@ -192,7 +191,7 @@ static struct {
                     }
                     else
 #endif
-                        [SwiftInjection injectWithOldClass:nil classNameOrFile:changed];
+                        [self.swiftInjection injectWithOldClass:nil classNameOrFile:changed];
                     break;
                 }
 #ifdef XPROBE_PORT
@@ -294,14 +293,14 @@ static struct {
 
         if ([SwiftEval sharedInstance].vaccineEnabled == YES) {
             resetRemapper();
-            [SwiftInjection vaccine:visibleVC];
+            [self.swiftInjection vaccine:visibleVC];
         } else {
             [visibleVC viewDidLoad];
             [visibleVC viewWillAppear:NO];
             [visibleVC viewDidAppear:NO];
 
 #ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-            [SwiftInjection flash:visibleVC];
+            [visibleVC flashToUpdate];
 #endif
         }
     }

--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -68,7 +68,13 @@ static struct {
 #if __has_include("macOSInjection10-Swift.h")
 #import "macOSInjection10-Swift.h"
 #else
+
+#if __has_include("macOSInjection-Swift.h")
 #import "macOSInjection-Swift.h"
+#elif __has_include("InjectionIII/InjectionIII-Swift.h")
+#import "InjectionIII/InjectionIII-Swift.h"
+#endif
+
 #endif
 #endif
 

--- a/InjectionBundle/NSObjectSwiftInjection.swift
+++ b/InjectionBundle/NSObjectSwiftInjection.swift
@@ -1,0 +1,23 @@
+//
+//  NSObjectSwiftInjection.swift
+//  InjectionBundle
+//
+//  Created by Francisco Javier Trujillo Mata on 23/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+import Foundation
+
+public extension NSObject {
+    
+    func inject() {
+        if let oldClass: AnyClass = object_getClass(self) {
+            SwiftInjection().inject(oldClass: oldClass, classNameOrFile: "\(oldClass)")
+        }
+    }
+    
+    @objc
+    class func inject(file: String) {
+        SwiftInjection().inject(oldClass: nil, classNameOrFile: file)
+    }
+}

--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -13,7 +13,6 @@
 //  Used as the basis of a new version of Injection.
 //
 
-#if arch(x86_64) || arch(i386) // simulator/macOS only
 import Foundation
 
 private func debug(_ str: String) {
@@ -693,5 +692,4 @@ func fork() -> Int32
 func execve(_ __file: UnsafePointer<Int8>!, _ __argv: UnsafePointer<UnsafeMutablePointer<Int8>?>!, _ __envp: UnsafePointer<UnsafeMutablePointer<Int8>?>!) -> Int32
 @_silgen_name("_NSGetEnviron")
 func _NSGetEnviron() -> UnsafePointer<UnsafePointer<UnsafeMutablePointer<Int8>?>?>!
-#endif
 #endif

--- a/InjectionBundle/UIViewControllerSwiftInjection.swift
+++ b/InjectionBundle/UIViewControllerSwiftInjection.swift
@@ -1,0 +1,48 @@
+//
+//  UIViewControllerSwiftInjection.swift
+//  InjectionBundle
+//
+//  Created by Francisco Javier Trujillo Mata on 23/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+import Foundation
+#if os(iOS) || os(tvOS)
+import UIKit
+
+public extension UIViewController {
+    
+    /// inject a UIView controller and redraw
+    public func injectVC() {
+        inject()
+        for subview in self.view.subviews {
+            subview.removeFromSuperview()
+        }
+        if let sublayers = self.view.layer.sublayers {
+            for sublayer in sublayers {
+                sublayer.removeFromSuperlayer()
+            }
+        }
+        viewDidLoad()
+    }
+    
+    @objc(flashToUpdate)
+    public func flashToUpdate() {
+        DispatchQueue.main.async {
+            let v = UIView(frame: self.view.frame)
+            v.backgroundColor = .white
+            v.alpha = 0.3
+            self.view.addSubview(v)
+            UIView.animate(withDuration: 0.2,
+                           delay: 0.0,
+                           options: UIViewAnimationOptions.curveEaseIn,
+                           animations: {
+                            v.alpha = 0.0
+            }, completion: { _ in v.removeFromSuperview() })
+        }
+    }
+}
+
+#else
+import Cocoa
+#endif

--- a/InjectionBundle/XCTestInjectionClient.h
+++ b/InjectionBundle/XCTestInjectionClient.h
@@ -1,0 +1,17 @@
+//
+//  XCTestInjectionClient.h
+//  InjectionBundle
+//
+//  Created by Francisco Javier Trujillo Mata on 23/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+#import "InjectionClient.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCTestInjectionClient : InjectionClient
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/InjectionBundle/XCTestInjectionClient.mm
+++ b/InjectionBundle/XCTestInjectionClient.mm
@@ -1,0 +1,59 @@
+//
+//  XCTestInjectionClient.m
+//  InjectionBundle
+//
+//  Created by Francisco Javier Trujillo Mata on 23/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+#import "XCTestInjectionClient.h"
+
+#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __has_include("tvOSInjection10-Swift.h")
+#import "tvOSInjection10-Swift.h"
+#elif __has_include("tvOSInjection-Swift.h")
+#import "tvOSInjection-Swift.h"
+#elif __has_include("iOSInjection10-Swift.h")
+#import "iOSInjection10-Swift.h"
+#else
+
+#if __has_include("iOSInjection-Swift.h")
+#import "iOSInjection-Swift.h"
+#elif __has_include("InjectionIII/InjectionIII-Swift.h")
+#import "InjectionIII/InjectionIII-Swift.h"
+#endif
+
+#endif
+
+#else
+
+#if __has_include("macOSInjection10-Swift.h")
+#import "macOSInjection10-Swift.h"
+#else
+
+#if __has_include("macOSInjection-Swift.h")
+#import "macOSInjection-Swift.h"
+#elif __has_include("InjectionIII/InjectionIII-Swift.h")
+#import "InjectionIII/InjectionIII-Swift.h"
+#endif
+
+#endif
+#endif
+
+@implementation XCTestInjectionClient
+
++ (void)load {
+    [self createInjectionClient];
+}
+
+- (SwiftInjection *)swiftInjection
+{
+    static SwiftInjection *_swiftInjection;
+    if (!_swiftInjection) {
+        _swiftInjection = [[XCTestSwiftInjection alloc] init];
+    }
+    
+    return _swiftInjection;
+}
+
+@end

--- a/InjectionBundle/XCTestSwiftInjection.swift
+++ b/InjectionBundle/XCTestSwiftInjection.swift
@@ -1,0 +1,44 @@
+//
+//  XCTestSwiftInjection.swift
+//  InjectionBundle
+//
+//  Created by Francisco Javier Trujillo Mata on 23/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@objc
+public class XCTestSwiftInjection: SwiftInjection {
+
+    static let testQueue = DispatchQueue(label: "INTestQueue")
+    var testClasses = [AnyClass]()
+    
+    override func appendTestClass(_ newClass: AnyClass) {
+        if newClass.isSubclass(of: XCTestCase.self) {
+            testClasses.append(newClass)
+        }
+    }
+    
+    override func proceedTestClasses()  {
+        // Thanks https://github.com/johnno1962/injectionforxcode/pull/234
+        if !testClasses.isEmpty {
+            XCTestSwiftInjection.testQueue.async {
+                XCTestSwiftInjection.testQueue.suspend()
+                let timer = Timer(timeInterval: 0, repeats:false, block: { _ in
+                    for newClass in self.testClasses {
+                        let suite0 = XCTestSuite(name: "Injected")
+                        let suite = XCTestSuite(forTestCaseClass: newClass)
+                        let tr = XCTestSuiteRun(test: suite)
+                        suite0.addTest(suite)
+                        suite0.perform(tr)
+                    }
+                    XCTestSwiftInjection.testQueue.resume()
+                })
+                RunLoop.main.add(timer, forMode: RunLoopMode.commonModes)
+            }
+        }
+    }
+        
+}

--- a/InjectionBundle/XprobeSwift-Bridging-Header.h
+++ b/InjectionBundle/XprobeSwift-Bridging-Header.h
@@ -2,8 +2,17 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#if __has_include("../XprobePlugin/Classes/Xtrace.h")
 #import "../XprobePlugin/Classes/Xtrace.h"
+#elif __has_include("Xtrace.h")
+#import "Xtrace.h"
+#endif
+
+#if __has_include("../XprobePlugin/Classes/Xprobe.h")
 #import "../XprobePlugin/Classes/Xprobe.h"
+#elif __has_include("Xprobe.h")
+#import "Xprobe.h"
+#endif
 
 @interface NSObject(InjectionSweep)
 - (void)bsweep;

--- a/InjectionIII.podspec
+++ b/InjectionIII.podspec
@@ -8,8 +8,8 @@ Pod::Spec.new do |s|
   s.author = 'John Holdsworth'
   s.source = { :git => 'https://github.com/johnno1962/InjectionIII.git', :tag => s.version }
 
-  s.platform = :ios, '9.0'
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.14'
   s.swift_version = '4.0'
 
   s.library     = 'z'

--- a/InjectionIII.podspec
+++ b/InjectionIII.podspec
@@ -1,0 +1,32 @@
+Pod::Spec.new do |s|
+  s.name = 'InjectionIII'
+  s.version = '1.5.2'
+  s.summary = "InjectionIII allows you make change in runtime over your app"
+  s.description = "Code injection allows you to update the implementation of methods of a class incrementally in the iOS simulator without having to rebuild or restart your application saving developer time."
+  s.homepage = 'http://injectionforxcode.com/'
+  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.author = 'John Holdsworth'
+  s.source = { :git => 'https://github.com/johnno1962/InjectionIII.git', :tag => s.version }
+
+  s.platform = :ios, '9.0'
+  s.ios.deployment_target = '8.0'
+  s.swift_version = '4.0'
+
+  s.library     = 'z'
+  s.framework   = 'XCTest'
+  s.xcconfig = { 'LD_RUNPATH_SEARCH_PATHS' => '$(PLATFORM_DIR)/Developer/Library/Frameworks' }
+
+  s.source_files  = 'InjectionBundle/InjectionClient.{h,mm}',
+                    'InjectionBundle/SwiftEval.swift',
+                    'InjectionBundle/SwiftInjection.swift',
+                    'InjectionBundle/Vaccine.swift',
+                    'InjectionBundle/XprobeSwift-Bridging-Header.h',
+                    'InjectionIII/InjectionEnum.h',
+                    'InjectionIII/SimpleSocket.{h,mm}',
+                    'XprobePlugin/Classes/Xprobe.h',
+                    'XprobePlugin/Classes/Xtrace.h',
+                    'XprobePlugin/XprobeSwift/SwiftSwizzler.swift',
+                    'XprobePlugin/XprobeSwift/XprobeSwift.swift'
+
+
+end

--- a/InjectionIII.podspec
+++ b/InjectionIII.podspec
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/johnno1962/InjectionIII.git', :tag => s.version }
 
   s.ios.deployment_target = '10.0'
-  s.osx.deployment_target = '10.14'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '10.0'
   s.swift_version = '4.0'
 
   s.library     = 'z'

--- a/InjectionIII.podspec
+++ b/InjectionIII.podspec
@@ -13,11 +13,10 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '10.0'
   s.swift_version = '4.0'
 
-  s.library     = 'z'
-  s.framework   = 'XCTest'
-  s.xcconfig = { 'LD_RUNPATH_SEARCH_PATHS' => '$(PLATFORM_DIR)/Developer/Library/Frameworks' }
-
+  s.library = 'z'
   s.source_files  = 'InjectionBundle/InjectionClient.{h,mm}',
+                    'InjectionBundle/NSObjectSwiftInjection.swift',
+                    'InjectionBundle/UIViewControllerSwiftInjection.swift',
                     'InjectionBundle/SwiftEval.swift',
                     'InjectionBundle/SwiftInjection.swift',
                     'InjectionBundle/Vaccine.swift',
@@ -29,5 +28,31 @@ Pod::Spec.new do |s|
                     'XprobePlugin/XprobeSwift/SwiftSwizzler.swift',
                     'XprobePlugin/XprobeSwift/XprobeSwift.swift'
 
+  s.default_subspec = 'Core'
+
+  s.subspec 'Core' do |ss|
+    ss.source_files = 'InjectionBundle/CoreInjectionClient.{h,mm}'
+  end
+
+  s.subspec 'Test' do |ss|
+    ss.source_files =   'InjectionBundle/InjectionClient.{h,mm}',
+                        'InjectionBundle/NSObjectSwiftInjection.swift',
+                        'InjectionBundle/UIViewControllerSwiftInjection.swift',
+                        'InjectionBundle/SwiftEval.swift',
+                        'InjectionBundle/SwiftInjection.swift',
+                        'InjectionBundle/Vaccine.swift',
+                        'InjectionBundle/XprobeSwift-Bridging-Header.h',
+                        'InjectionIII/InjectionEnum.h',
+                        'InjectionIII/SimpleSocket.{h,mm}',
+                        'XprobePlugin/Classes/Xprobe.h',
+                        'XprobePlugin/Classes/Xtrace.h',
+                        'XprobePlugin/XprobeSwift/SwiftSwizzler.swift',
+                        'XprobePlugin/XprobeSwift/XprobeSwift.swift',
+                        'InjectionBundle/XCTestInjectionClient.{h,mm}',
+                        'InjectionBundle/XCTestSwiftInjection.swift'
+    ss.framework = 'XCTest'
+    ss.xcconfig = { 'LD_RUNPATH_SEARCH_PATHS' => '$(PLATFORM_DIR)/Developer/Library/Frameworks' }
+    ss.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
+  end
 
 end

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B5BEC895226F89A400C96067 /* NSObjectSwiftInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEC894226F89A400C96067 /* NSObjectSwiftInjection.swift */; };
+		B5BEC897226F8A5500C96067 /* UIViewControllerSwiftInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEC896226F8A5500C96067 /* UIViewControllerSwiftInjection.swift */; };
+		B5BEC899226F938000C96067 /* XCTestSwiftInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEC898226F938000C96067 /* XCTestSwiftInjection.swift */; };
+		B5BEC8A1226FB69B00C96067 /* XCTestInjectionClient.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5BEC8A0226FB69B00C96067 /* XCTestInjectionClient.mm */; };
 		BB439B801FABA64300B4F50B /* SwiftEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB439B7F1FABA64300B4F50B /* SwiftEvalTests.swift */; };
 		BB56393C1FD5C25A002FFCEF /* SignerService.m in Sources */ = {isa = PBXBuildFile; fileRef = BB67DBB61FB0D0F2000EAC8A /* SignerService.m */; };
 		BB6306FE1FCD1A410021D30C /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = BB6306FD1FCD1A410021D30C /* Credits.rtf */; };
@@ -77,6 +81,13 @@
 
 /* Begin PBXFileReference section */
 		B53A8EE3226937350016D773 /* InjectionEnum.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InjectionEnum.h; sourceTree = "<group>"; };
+		B5BEC894226F89A400C96067 /* NSObjectSwiftInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectSwiftInjection.swift; sourceTree = "<group>"; };
+		B5BEC896226F8A5500C96067 /* UIViewControllerSwiftInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerSwiftInjection.swift; sourceTree = "<group>"; };
+		B5BEC898226F938000C96067 /* XCTestSwiftInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestSwiftInjection.swift; sourceTree = "<group>"; };
+		B5BEC89C226FB64600C96067 /* CoreInjectionClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreInjectionClient.h; sourceTree = "<group>"; };
+		B5BEC89D226FB64600C96067 /* CoreInjectionClient.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreInjectionClient.mm; sourceTree = "<group>"; };
+		B5BEC89F226FB69B00C96067 /* XCTestInjectionClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCTestInjectionClient.h; sourceTree = "<group>"; };
+		B5BEC8A0226FB69B00C96067 /* XCTestInjectionClient.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = XCTestInjectionClient.mm; sourceTree = "<group>"; };
 		BB037DF31FAD808B004B267C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BB037DF41FAD80D0004B267C /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		BB109FAF1FAECD92008C5218 /* SwiftInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftInjection.swift; sourceTree = "<group>"; };
@@ -368,10 +379,17 @@
 				BBCA02471FB1065D00E45F0F /* Info.plist */,
 				BBCA025B1FB114FF00E45F0F /* InjectionClient.h */,
 				BBCA025C1FB114FF00E45F0F /* InjectionClient.mm */,
+				B5BEC89C226FB64600C96067 /* CoreInjectionClient.h */,
+				B5BEC89D226FB64600C96067 /* CoreInjectionClient.mm */,
+				B5BEC89F226FB69B00C96067 /* XCTestInjectionClient.h */,
+				B5BEC8A0226FB69B00C96067 /* XCTestInjectionClient.mm */,
 				BB439B8A1FABA65D00B4F50B /* SwiftEval.swift */,
 				BB109FAF1FAECD92008C5218 /* SwiftInjection.swift */,
+				B5BEC898226F938000C96067 /* XCTestSwiftInjection.swift */,
 				BBB64FE41FD576AA0020BE47 /* XprobeSwift-Bridging-Header.h */,
 				BD35949D21A6C5DE0020EB94 /* Vaccine.swift */,
+				B5BEC894226F89A400C96067 /* NSObjectSwiftInjection.swift */,
+				B5BEC896226F8A5500C96067 /* UIViewControllerSwiftInjection.swift */,
 			);
 			path = InjectionBundle;
 			sourceTree = "<group>";
@@ -636,10 +654,14 @@
 				BBCA02501FB107AF00E45F0F /* SwiftEval.swift in Sources */,
 				BD35949E21A6C5DE0020EB94 /* Vaccine.swift in Sources */,
 				BBCA02511FB107AF00E45F0F /* SwiftInjection.swift in Sources */,
+				B5BEC8A1226FB69B00C96067 /* XCTestInjectionClient.mm in Sources */,
 				BBB64FE11FD575260020BE47 /* XprobeSwift.swift in Sources */,
 				BBB64FE61FD577EB0020BE47 /* SwiftSwizzler.swift in Sources */,
 				BBCA02621FB1312A00E45F0F /* SimpleSocket.mm in Sources */,
 				BBCA025D1FB114FF00E45F0F /* InjectionClient.mm in Sources */,
+				B5BEC899226F938000C96067 /* XCTestSwiftInjection.swift in Sources */,
+				B5BEC895226F89A400C96067 /* NSObjectSwiftInjection.swift in Sources */,
+				B5BEC897226F8A5500C96067 /* UIViewControllerSwiftInjection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B53A8EE3226937350016D773 /* InjectionEnum.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InjectionEnum.h; sourceTree = "<group>"; };
 		BB037DF31FAD808B004B267C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		BB037DF41FAD80D0004B267C /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		BB109FAF1FAECD92008C5218 /* SwiftInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftInjection.swift; sourceTree = "<group>"; };
@@ -335,6 +336,7 @@
 				BBEB704B1FD28C6F00127711 /* XcodeHash.m */,
 				BBCA02001FB0F10300E45F0F /* AppDelegate.h */,
 				BBCA02011FB0F10300E45F0F /* AppDelegate.mm */,
+				B53A8EE3226937350016D773 /* InjectionEnum.h */,
 				BBCA02541FB1099500E45F0F /* InjectionServer.h */,
 				BBCA02551FB1099500E45F0F /* InjectionServer.mm */,
 				BB67DBB21FB0CDA8000EAC8A /* SimpleSocket.h */,

--- a/InjectionIII/InjectionEnum.h
+++ b/InjectionIII/InjectionEnum.h
@@ -1,0 +1,35 @@
+//
+//  InjectionEnum.h
+//  InjectionIII
+//
+//  Created by Francisco Javier Trujillo Mata on 19/04/2019.
+//  Copyright © 2019 John Holdsworth. All rights reserved.
+//
+
+#ifndef InjectionEnum_h
+#define InjectionEnum_h
+
+#define INJECTION_ADDRESS @":8898"
+#define INJECTION_KEY @"bvijkijyhbtrbrebzjbbzcfbbvvq"
+
+typedef NS_ENUM(int, InjectionCommand) {
+    // responses from bundle
+    InjectionComplete,
+    InjectionPause,
+    InjectionSign,
+    InjectionError,
+    
+    // commands to Bundle
+    InjectionProject,
+    InjectionLog,
+    InjectionSigned,
+    InjectionLoad,
+    InjectionInject,
+    InjectionXprobe,
+    InjectionEval,
+    InjectionVaccineSettingChanged,
+    
+    InjectionEOF = ~0
+};
+
+#endif /* InjectionEnum_h */

--- a/InjectionIII/InjectionServer.h
+++ b/InjectionIII/InjectionServer.h
@@ -7,9 +7,7 @@
 //
 
 #import "SimpleSocket.h"
-
-#define INJECTION_ADDRESS @":8898"
-#define INJECTION_KEY @"bvijkijyhbtrbrebzjbbzcfbbvvq"
+#import "InjectionEnum.h"
 
 @interface InjectionServer : SimpleSocket
 
@@ -17,23 +15,3 @@
 - (void)injectPending;
 
 @end
-
-typedef NS_ENUM(int, InjectionCommand) {
-    // responses from bundle
-    InjectionComplete,
-    InjectionPause,
-    InjectionSign,
-    InjectionError,
-
-    // commands to Bundle
-    InjectionProject,
-    InjectionLog,
-    InjectionSigned,
-    InjectionLoad,
-    InjectionInject,
-    InjectionXprobe,
-    InjectionEval,
-    InjectionVaccineSettingChanged,
-
-    InjectionEOF = ~0
-};


### PR DESCRIPTION
### OVERVIEW

This PR is just making easier the integration in the project, taking into advantage the `CocoaPods` platform.

Now if the user wants to include `InjectionIII` in his project, he/she just needs to include in the `Podfile` something like:

`pod 'InjectionIII' , :configurations => ['Debug']`

How `InjectionClient` is overriding the `+ (void)load` method is not longer needed to add additional lines into the `AppDelegate`

If you need help, testing it or uploading to `CocoaPods`, just contact me, I would like to support you.

Thanks