### PR TITLE
Remove redundant use of Xcode scripting interface

### DIFF
--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -164,8 +164,14 @@ public class SwiftInjection: NSObject {
             }
         } else {
             var injectedClasses = [AnyClass]()
+            let injectedSEL = #selector(SwiftInjected.injected)
+            typealias ClassIMP = @convention(c) (AnyClass, Selector) -> ()
             for cls in oldClasses {
-                if class_getInstanceMethod(cls, #selector(SwiftInjected.injected)) != nil {
+                if let classMethod = class_getClassMethod(cls, injectedSEL) {
+                    let classIMP = method_getImplementation(classMethod)
+                    unsafeBitCast(classIMP, to: ClassIMP.self)(cls, injectedSEL)
+                }
+                if class_getInstanceMethod(cls, injectedSEL) != nil {
                     injectedClasses.append(cls)
                     let kvoName = "NSKVONotifying_" + NSStringFromClass(cls)
                     if let kvoCls = NSClassFromString(kvoName) {

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -5,7 +5,7 @@
 //  Created by John Holdsworth on 05/11/2017.
 //  Copyright © 2017 John Holdsworth. All rights reserved.
 //
-//  $Id: //depot/ResidentEval/InjectionBundle/SwiftInjection.swift#54 $
+//  $Id: //depot/ResidentEval/InjectionBundle/SwiftInjection.swift#55 $
 //
 //  Cut-down version of code injection in Swift. Uses code
 //  from SwiftEval.swift to recompile and reload class.

--- a/InjectionIII/InjectionServer.mm
+++ b/InjectionIII/InjectionServer.mm
@@ -49,12 +49,12 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
     NSString *projectFile = appDelegate.selectedProject;
     static BOOL MAS = false;
 
-    if (!projectFile) {
-        XcodeApplication *xcode = (XcodeApplication *)[SBApplication
-                           applicationWithBundleIdentifier:XcodeBundleID];
-        XcodeWorkspaceDocument *workspace = [xcode activeWorkspaceDocument];
-        projectFile = workspace.file.path;
-    }
+//    if (!projectFile) {
+//        XcodeApplication *xcode = (XcodeApplication *)[SBApplication
+//                           applicationWithBundleIdentifier:XcodeBundleID];
+//        XcodeWorkspaceDocument *workspace = [xcode activeWorkspaceDocument];
+//        projectFile = workspace.file.path;
+//    }
 
     if (!projectFile) {
         dispatch_sync(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Hi @zenangst,

A final change after testing on Catalina to remove some old code that was causing a crash as the Xcode scripting interface seems to have been removed.

John

