### PR TITLE
Last minute fix for injecting apps using MKMapView

### DIFF
--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -164,8 +164,14 @@ public class SwiftInjection: NSObject {
             }
         } else {
             var injectedClasses = [AnyClass]()
+            let injectedSEL = #selector(SwiftInjected.injected)
+            typealias ClassIMP = @convention(c) (AnyClass, Selector) -> ()
             for cls in oldClasses {
-                if class_getInstanceMethod(cls, #selector(SwiftInjected.injected)) != nil {
+                if let classMethod = class_getClassMethod(cls, injectedSEL) {
+                    let classIMP = method_getImplementation(classMethod)
+                    unsafeBitCast(classIMP, to: ClassIMP.self)(cls, injectedSEL)
+                }
+                if class_getInstanceMethod(cls, injectedSEL) != nil {
                     injectedClasses.append(cls)
                     let kvoName = "NSKVONotifying_" + NSStringFromClass(cls)
                     if let kvoCls = NSClassFromString(kvoName) {

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -5,7 +5,7 @@
 //  Created by John Holdsworth on 05/11/2017.
 //  Copyright © 2017 John Holdsworth. All rights reserved.
 //
-//  $Id: //depot/ResidentEval/InjectionBundle/SwiftInjection.swift#54 $
+//  $Id: //depot/ResidentEval/InjectionBundle/SwiftInjection.swift#55 $
 //
 //  Cut-down version of code injection in Swift. Uses code
 //  from SwiftEval.swift to recompile and reload class.

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.2</string>
+	<string>1.6</string>
 	<key>CFBundleVersion</key>
-	<string>1745</string>
+	<string>1826</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/InjectionServer.mm
+++ b/InjectionIII/InjectionServer.mm
@@ -49,12 +49,12 @@ static NSMutableDictionary *projectInjected = [NSMutableDictionary new];
     NSString *projectFile = appDelegate.selectedProject;
     static BOOL MAS = false;
 
-    if (!projectFile) {
-        XcodeApplication *xcode = (XcodeApplication *)[SBApplication
-                           applicationWithBundleIdentifier:XcodeBundleID];
-        XcodeWorkspaceDocument *workspace = [xcode activeWorkspaceDocument];
-        projectFile = workspace.file.path;
-    }
+//    if (!projectFile) {
+//        XcodeApplication *xcode = (XcodeApplication *)[SBApplication
+//                           applicationWithBundleIdentifier:XcodeBundleID];
+//        XcodeWorkspaceDocument *workspace = [xcode activeWorkspaceDocument];
+//        projectFile = workspace.file.path;
+//    }
 
     if (!projectFile) {
         dispatch_sync(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Hi @zenangst,

Another PR.... This resolves an issue whereSwiftUI examples using MKMapView were causing a very nasty crash. This is resolved by starting a process dedicated to running scripts before any of the problematic view classes are used in an interface. This may have affected non-SwiftUI injection all along. It communicates with the injecting process using a simple line-based IPC sending the path to a script to run and returning the status. Though this is a change in the mechanics of injection the change is localised and should low risk.

John