### PR TITLE
Updated FileWatcher to also respond to item modified event

### DIFF
--- a/InjectionIII/FileWatcher.m
+++ b/InjectionIII/FileWatcher.m
@@ -24,7 +24,7 @@ static void fileCallback(ConstFSEventStreamRef streamRef,
     BOOL shouldRespondToFileChange = NO;
     for (int i = 0; i < numEvents; i++) {
         uint32 flag = eventFlags[i];
-        if (flag & kFSEventStreamEventFlagItemRenamed) {
+        if (flag & (kFSEventStreamEventFlagItemRenamed | kFSEventStreamEventFlagItemModified)) {
             shouldRespondToFileChange = YES;
             break;
         }


### PR DESCRIPTION
The file watcher was not getting triggered when modifying files in AppCode (or Sublime) only in Xcode. When modifying the file (outside of Xcode) the event `kFSEventStreamEventFlagItemModified` is getting triggered instead of `kFSEventStreamEventFlagItemRenamed`.