### PR TITLE
Reset dylib to prevent macOS 10.15 from blocking it

### DIFF
--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -363,6 +363,12 @@ public class SwiftEval: NSObject {
             #endif
         }
 
+        // Reset dylib to prevent macOS 10.15 from blocking it
+        let dylib = try Data(contentsOf: URL(fileURLWithPath: "\(tmpfile).dylib"))
+        let url = URL(fileURLWithPath: "\(tmpfile).dylib")
+        try filemgr.removeItem(at: url)
+        try dylib.write(to: url)
+
         return tmpfile
     }
 

--- a/InjectionIII/FileWatcher.m
+++ b/InjectionIII/FileWatcher.m
@@ -24,7 +24,7 @@ static void fileCallback(ConstFSEventStreamRef streamRef,
     BOOL shouldRespondToFileChange = NO;
     for (int i = 0; i < numEvents; i++) {
         uint32 flag = eventFlags[i];
-        if (flag & kFSEventStreamEventFlagItemRenamed) {
+        if (flag & (kFSEventStreamEventFlagItemRenamed | kFSEventStreamEventFlagItemModified)) {
             shouldRespondToFileChange = YES;
             break;
         }


### PR DESCRIPTION
On macOS 10.15 (Catalina), the injected dylib was being blocked by macOS, @johnno1962 solve this issue by "reseting" the dylib, and rewriting it with the simulator.

Reference Issue: https://github.com/johnno1962/InjectionIII/issues/178