### PR TITLE
Remove (Beta) from Trace title

### DIFF
--- a/InjectionIII/Base.lproj/MainMenu.xib
+++ b/InjectionIII/Base.lproj/MainMenu.xib
@@ -711,7 +711,7 @@
                         <action selector="runXprobe:" target="Voe-Tx-rLC" id="OLt-ZD-lyd"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Trace (Beta)" id="Kkx-ex-NCv">
+                <menuItem title="Trace" id="Kkx-ex-NCv">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="traceApp:" target="Voe-Tx-rLC" id="5zd-Ho-CaT"/>


### PR DESCRIPTION
App Store does not allow beta features so we are not allowed to use this kind of wording
in InjectionIII. It will result with an immediate rejection.