### PR TITLE
Add AppCode support (fixes #147, #49)

### DIFF
--- a/InjectionBundle/InjectionClient.h
+++ b/InjectionBundle/InjectionClient.h
@@ -23,6 +23,7 @@ typedef NS_ENUM(int, InjectionCommand) {
     InjectionSigned,
     InjectionLoad,
     InjectionInject,
+    InjectionIdeProcPath,
     InjectionXprobe,
     InjectionEval,
     InjectionVaccineSettingChanged,

--- a/InjectionBundle/InjectionClient.mm
+++ b/InjectionBundle/InjectionClient.mm
@@ -181,6 +181,10 @@ static struct {
         case InjectionUntrace:
             [SwiftTrace removeAllPatches];
             break;
+        case InjectionIdeProcPath: {
+            [SwiftEval sharedInstance].lastIdeProcPath = [self readString];
+            break;
+        }
         default: {
             NSString *changed = [self readString];
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/InjectionIII/InjectionIII-Bridging-Header.h
+++ b/InjectionIII/InjectionIII-Bridging-Header.h
@@ -13,6 +13,7 @@
 #import "InjectionClient.h"
 
 #import "DDHotKeyCenter.h"
+#import <libproc.h>
 
 #ifdef XPROBE_PORT
 #import "../XprobePlugin/Classes/XprobePluginMenuController.h"

--- a/InjectionIII/InjectionServer.swift
+++ b/InjectionIII/InjectionServer.swift
@@ -15,10 +15,10 @@ var projectInjected = ["": ["": Date.timeIntervalSinceReferenceDate]]
 let MIN_INJECTION_INTERVAL = 1.0
 
 public class InjectionServer: SimpleSocket {
-    var injector: ((_ changed: NSArray) -> Void)? = nil
+    var injector: ((_ changed: NSArray, _ ideProcPath:String) -> Void)? = nil
     var fileWatchers = [FileWatcher]()
     var pending = [String]()
-
+    var lastIdeProcPath = ""
     override public class func error(_ message: String) -> Int32 {
         let saveno = errno
         DispatchQueue.main.sync {
@@ -162,7 +162,7 @@ public class InjectionServer: SimpleSocket {
         var testCache = [String: [String]]()
 
         injector = {
-            (changed: NSArray) in
+            (changed: NSArray, ideProcPath: String) in
             var changed = changed as! [String]
 
             if UserDefaults.standard.bool(forKey: UserDefaultsTDDEnabled) {
@@ -195,7 +195,7 @@ public class InjectionServer: SimpleSocket {
                     }
                 }
             }
-
+            self.lastIdeProcPath = ideProcPath
             if (automatic) {
                 self.injectPending()
             }
@@ -259,6 +259,7 @@ public class InjectionServer: SimpleSocket {
     @objc public func injectPending() {
         for swiftSource in pending {
             injectionQueue.async {
+                self.sendCommand(.ideProcPath, with: self.lastIdeProcPath)
                 self.sendCommand(.inject, with:swiftSource)
             }
         }


### PR DESCRIPTION
This PR is a result of 1.8 review after [this](https://github.com/johnno1962/InjectionIII/issues/49) conversation. Finally I found that we still need to build the application in Xcode, so I've decided to implement a patch to correctly identify AppCode version. Some random notes:

1. AppCode < 2020.1 uses ```~/Library/Caches/AppCode<major>.<minor>``` for storing out custom DerivedData
2. AppCode >= 2020.1 uses ```~/Library/Caches/JetBrains/AppCode<major>.<minor>``` for storing out custom DerivedData
3. ```idea.path.selector``` is used to identify the cache directory with DerivedData. If nothing is found for the current release, we use previous release version. 
4. If nothing is found after all, we default to Xcode DerivedData. 
5. If some another editor is used that is not AppCode - we think it's Xcode and use Xcode's DerivedData. 

Tested - works starting with AppCode 2019.3, works simultaneously in Xcode, AppCode 2020.1, AppCode 2019.3 and any other editor. 