### PR TITLE
Sweep failure message.

### DIFF
--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -173,6 +173,13 @@ public class SwiftInjection: NSObject {
                 }
                 if class_getInstanceMethod(cls, injectedSEL) != nil {
                     injectedClasses.append(cls)
+                    print("""
+                        💉 Class \(cls) has an @objc injected() method. \
+                        Injection will attempt a "sweep" of all live \
+                        instances to determine which objects to message. \
+                        If this crashes, subscribe to the global notification \
+                        "INJECTION_BUNDLE_NOTIFICATION" to detect injections instead.
+                        """)
                     let kvoName = "NSKVONotifying_" + NSStringFromClass(cls)
                     if let kvoCls = NSClassFromString(kvoName) {
                         injectedClasses.append(kvoCls)


### PR DESCRIPTION
To give people a bit more to go on if the sweep fails, such as in issue https://github.com/johnno1962/InjectionIII/issues/209, print a message just before starting the sweep to suggest using “INJECTION_BUNDLE_NOTIFICATION” instead if it crashes. This does however create a bit more noise each time you inject. What do think @zenangst?