### PR TITLE
Fix crash when sweeping values

### DIFF
--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -271,6 +271,10 @@ class SwiftSweeper {
     }
 
     func sweepValue(_ value: Any) {
+        /// Skip values that cannot be cast into `AnyObject` because they end up being `nil`
+        /// Fixes a potential crash that the value is not accessible during injection.
+        guard value as? AnyObject != nil else { return }
+
         let mirror = Mirror(reflecting: value)
         if var style = mirror.displayStyle {
             if _typeName(mirror.subjectType).hasPrefix("Swift.ImplicitlyUnwrappedOptional<") {

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2426</string>
+	<string>2437</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
I had a recurring crash in a client project and managed to trace it back to a class that held an instance `FirebaseRemoteConfig` which is an Objective-C framework. By digging deeper I saw that `sweepValue` ended up crashing with `EXC_BAD_ACCESS`.

```
(lldb) po value
expression produced error: error: Execution was interrupted, reason: EXC_BAD_ACCESS (code=1, address=0x0).
The process has been returned to the state before expression evaluation.
```

I managed to reproduce this and ended up with the following fix, so far I've seen no negative side-effects with the micro-additional work that `sweepValue` needs to do extra.

First cast the value to `AnyObject` then check that the value isn't `nil`.

This one is a bit iffy because we will get a warning stating that this will always succeed.
In our case, we get `Any` from `Mirror` which doesn't give us any clue if the value is present or not. To work around the non-optional, we try and first cast the object and then check the result as trying to cast the underlying object will end up in failing even if the compiler message tells us otherwise.