### PR TITLE
LD_RUNPATH_SEARCH_PATHS problem.

### DIFF
--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2854</string>
+	<string>2856</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/build_bundles.sh
+++ b/InjectionIII/build_bundles.sh
@@ -7,10 +7,9 @@
 #  Copyright © 2019 John Holdsworth. All rights reserved.
 
 SYMROOT=/tmp/Injection
-export PLATFORM_DIR_OS=$DEVELOPER_DIR/Platforms/iPhoneSimulator.platform &&
-"$DEVELOPER_BIN_DIR"/xcodebuild SYMROOT=$SYMROOT PRODUCT_NAME=iOSInjection LD_RUNPATH_SEARCH_PATHS="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator $PLATFORM_DIR_OS/Developer/Library/Frameworks @loader_path/Frameworks" -arch x86_64 -sdk iphonesimulator -config Debug -target InjectionBundle &&
+export XCODE_PLATFORM_DIR=/Applications/Xcode.app/Contents/Developer/Platforms &&
+"$DEVELOPER_BIN_DIR"/xcodebuild SYMROOT=$SYMROOT PRODUCT_NAME=iOSInjection LD_RUNPATH_SEARCH_PATHS="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator $XCODE_PLATFORM_DIR/iPhoneSimulator.platform/Developer/Library/Frameworks @loader_path/Frameworks" -arch x86_64 -sdk iphonesimulator -config Debug -target InjectionBundle &&
 rsync -au $SYMROOT/Debug-iphonesimulator/iOSInjection.bundle  "$CODESIGNING_FOLDER_PATH/Contents/Resources" &&
-export PLATFORM_DIR_OS=$DEVELOPER_DIR/Platforms/AppleTVSimulator.platform &&
-"$DEVELOPER_BIN_DIR"/xcodebuild SYMROOT=$SYMROOT PRODUCT_NAME=tvOSInjection LD_RUNPATH_SEARCH_PATHS="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator $PLATFORM_DIR_OS/Developer/Library/Frameworks @loader_path/Frameworks" -arch x86_64 -sdk appletvsimulator -config Debug -target InjectionBundle &&
+"$DEVELOPER_BIN_DIR"/xcodebuild SYMROOT=$SYMROOT PRODUCT_NAME=tvOSInjection LD_RUNPATH_SEARCH_PATHS="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator $XCODE_PLATFORM_DIR/AppleTVSimulator.platform/Developer/Library/Frameworks @loader_path/Frameworks" -arch x86_64 -sdk appletvsimulator -config Debug -target InjectionBundle &&
 rsync -au $SYMROOT/Debug-appletvsimulator/tvOSInjection.bundle  "$CODESIGNING_FOLDER_PATH/Contents/Resources" &&
 find $CODESIGNING_FOLDER_PATH/Contents/Resources/*.bundle -name '*.h' -delete


### PR DESCRIPTION
Resolves problem preparing release when you build with an Xcode not at /Applications/Xcode.app.