### PR TITLE
Re-enable "old-style" injection for now

### DIFF
--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -442,6 +442,14 @@ public class SwiftEval: NSObject {
             let error = String(cString: dlerror())
             if error.contains("___llvm_profile_runtime") {
                 print("💉 Loading .dylib has failed, try turning off collection of test coverage in your scheme")
+            } else if error.contains("Symbol not found:") {
+                print("""
+                    💉 Loading .dylib has failed, This may be because Swift \
+                    code being injected refers to a function with a default \
+                    argument. Consult the section in the README at \
+                    https://github.com/johnno1962/InjectionIII about \
+                    using \"unhide\".
+                    """)
             }
             throw evalError("dlopen() error: \(error)")
         }

--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -13,7 +13,7 @@
 //  Used as the basis of a new version of Injection.
 //
 
-#if arch(x86_64) || arch(i386) // simulator/macOS only
+#if arch(x86_64) || arch(i386) || arch(arm64) // simulator/macOS only
 import Foundation
 
 private func debug(_ str: String) {

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -11,7 +11,7 @@
 //  from SwiftEval.swift to recompile and reload class.
 //
 
-#if arch(x86_64) || arch(i386) // simulator/macOS only
+#if arch(x86_64) || arch(i386) || arch(arm64) // simulator/macOS only
 import Foundation
 import XCTest
 

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -127,7 +127,7 @@ public class SwiftInjection: NSObject {
                     print("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
                 }
 
-                #if false // replaced by "interpose" code below
+                #if true // to be replaced by "interpose" code below
                 func byteAddr<T>(_ location: UnsafeMutablePointer<T>) -> UnsafeMutablePointer<UInt8> {
                     return location.withMemoryRebound(to: UInt8.self, capacity: 1) { $0 }
                 }

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -173,6 +173,7 @@ public class SwiftInjection: NSObject {
                 interposed[existing] = loadedFunc
                 interposed[current] = loadedFunc
                 print("💉 Replacing \(demangle(symbol))")
+//                print("💉 Replacing \(demangle(symbol))")
             }
         }
 

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -160,7 +160,7 @@ public class SwiftInjection: NSObject {
 
         // Find all definitions of Swift functions and ...
         // SwiftUI body properties defined in the new dylib.
-        for suffix in ["fC", "yF", "lF", "tF", "Qrvg"] {
+        for suffix in ["fC", "yF", "lF", "tF", "Qrvg"] {//, "CN", "Mf", "Mn", "Tq"] {
             findSwiftFunctions("\(tmpfile).dylib", suffix) {
                 (loadedFunc, symbol) in
                 guard let existing = dlsym(main, symbol) else { return }
@@ -172,7 +172,6 @@ public class SwiftInjection: NSObject {
                 // record functions that have beeen interposed
                 interposed[existing] = loadedFunc
                 interposed[current] = loadedFunc
-                print("💉 Replacing \(demangle(symbol))")
 //                print("💉 Replacing \(demangle(symbol))")
             }
         }

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BB34C3FF244FAD3C00D520A9 /* log.html in Resources */ = {isa = PBXBuildFile; fileRef = BB34C3FE244FAD3C00D520A9 /* log.html */; };
 		BB34C401244FAE3000D520A9 /* iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = BB34C400244FAE2F00D520A9 /* iphone.png */; };
 		BB439B801FABA64300B4F50B /* SwiftEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB439B7F1FABA64300B4F50B /* SwiftEvalTests.swift */; };
+		BB4ADF7724E8036400D502F3 /* xt_forwarding_trampoline_arm64.s in Sources */ = {isa = PBXBuildFile; fileRef = BB4ADF7624E8036400D502F3 /* xt_forwarding_trampoline_arm64.s */; };
 		BB4EC3FB244FA3C40079E244 /* RMMacroManager.m in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC3F7244FA3C30079E244 /* RMMacroManager.m */; };
 		BB4EC3FC244FA3C40079E244 /* RMDeviceController.m in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC3F8244FA3C30079E244 /* RMDeviceController.m */; };
 		BB4EC3FD244FA3C40079E244 /* RMImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = BB4EC3F9244FA3C40079E244 /* RMImageView.m */; };
@@ -120,6 +121,7 @@
 		BB439B8A1FABA65D00B4F50B /* SwiftEval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftEval.swift; sourceTree = "<group>"; };
 		BB439BAC1FAC030E00B4F50B /* SwiftEval.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftEval.entitlements; sourceTree = "<group>"; };
 		BB439BB31FAC185200B4F50B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		BB4ADF7624E8036400D502F3 /* xt_forwarding_trampoline_arm64.s */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; name = xt_forwarding_trampoline_arm64.s; path = SwiftTrace/SwiftTraceGuts/xt_forwarding_trampoline_arm64.s; sourceTree = SOURCE_ROOT; };
 		BB4EC3F7244FA3C30079E244 /* RMMacroManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RMMacroManager.m; path = Remote/Classes/RMMacroManager.m; sourceTree = SOURCE_ROOT; };
 		BB4EC3F8244FA3C30079E244 /* RMDeviceController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RMDeviceController.m; path = Remote/Classes/RMDeviceController.m; sourceTree = SOURCE_ROOT; };
 		BB4EC3F9244FA3C40079E244 /* RMImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RMImageView.m; path = Remote/Classes/RMImageView.m; sourceTree = SOURCE_ROOT; };
@@ -439,6 +441,7 @@
 				BB5D67AA244DA00B003AA7F4 /* SwiftMeta.swift */,
 				BB5D67AC244DA00C003AA7F4 /* SwiftStack.swift */,
 				BB76EA0722929E1100E454F0 /* xt_forwarding_trampoline_x64.s */,
+				BB4ADF7624E8036400D502F3 /* xt_forwarding_trampoline_arm64.s */,
 			);
 			path = InjectionBundle;
 			sourceTree = "<group>";
@@ -699,6 +702,7 @@
 			files = (
 				BBCA02501FB107AF00E45F0F /* SwiftEval.swift in Sources */,
 				BB76EA0822929E1100E454F0 /* SwiftTrace.mm in Sources */,
+				BB4ADF7724E8036400D502F3 /* xt_forwarding_trampoline_arm64.s in Sources */,
 				BD35949E21A6C5DE0020EB94 /* Vaccine.swift in Sources */,
 				BBCA02511FB107AF00E45F0F /* SwiftInjection.swift in Sources */,
 				BB5D67B1244DA00C003AA7F4 /* SwiftInvoke.swift in Sources */,

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -935,7 +935,7 @@
 				INFOPLIST_FILE = InjectionIII/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionIII;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -958,7 +958,7 @@
 				INFOPLIST_FILE = InjectionIII/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionIII;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		BB5D67B0244DA00C003AA7F4 /* SwiftMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5D67AA244DA00B003AA7F4 /* SwiftMeta.swift */; };
 		BB5D67B1244DA00C003AA7F4 /* SwiftInvoke.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5D67AB244DA00C003AA7F4 /* SwiftInvoke.swift */; };
 		BB5D67B2244DA00C003AA7F4 /* SwiftStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5D67AC244DA00C003AA7F4 /* SwiftStack.swift */; };
+		BB6125D324EA882000A7C230 /* Injection.jar in Resources */ = {isa = PBXBuildFile; fileRef = BB6125D224EA882000A7C230 /* Injection.jar */; };
 		BB620E6824BA3F4B002FACC5 /* Interposer.mm in Sources */ = {isa = PBXBuildFile; fileRef = BB620E6724BA3F4B002FACC5 /* Interposer.mm */; };
 		BB6306FE1FCD1A410021D30C /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = BB6306FD1FCD1A410021D30C /* Credits.rtf */; };
 		BB76EA0822929E1100E454F0 /* SwiftTrace.mm in Sources */ = {isa = PBXBuildFile; fileRef = BB76EA0522929E1100E454F0 /* SwiftTrace.mm */; };
@@ -137,6 +138,7 @@
 		BB5D67AA244DA00B003AA7F4 /* SwiftMeta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftMeta.swift; path = SwiftTrace/SwiftTrace/SwiftMeta.swift; sourceTree = SOURCE_ROOT; };
 		BB5D67AB244DA00C003AA7F4 /* SwiftInvoke.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftInvoke.swift; path = SwiftTrace/SwiftTrace/SwiftInvoke.swift; sourceTree = SOURCE_ROOT; };
 		BB5D67AC244DA00C003AA7F4 /* SwiftStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftStack.swift; path = SwiftTrace/SwiftTrace/SwiftStack.swift; sourceTree = SOURCE_ROOT; };
+		BB6125D224EA882000A7C230 /* Injection.jar */ = {isa = PBXFileReference; lastKnownFileType = archive.jar; name = Injection.jar; path = AppCodePlugin/Injection.jar; sourceTree = "<group>"; };
 		BB620E6724BA3F4B002FACC5 /* Interposer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Interposer.mm; sourceTree = "<group>"; };
 		BB6224411FC5B0E300AD7A3A /* HelperProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HelperProxy.m; sourceTree = "<group>"; };
 		BB6224421FC5B0E500AD7A3A /* HelperProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HelperProxy.h; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 			children = (
 				BB037DF41FAD80D0004B267C /* LICENSE */,
 				BB037DF31FAD808B004B267C /* README.md */,
+				BB6125D224EA882000A7C230 /* Injection.jar */,
 				BBCA01FF1FB0F10300E45F0F /* InjectionIII */,
 				BBCA02461FB1065D00E45F0F /* InjectionBundle */,
 				BB6224481FC5B13D00AD7A3A /* Bootstrap */,
@@ -595,6 +598,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BB6125D324EA882000A7C230 /* Injection.jar in Resources */,
 				BB85A7412452CD7600E94762 /* SwiftTrace.h in Resources */,
 				BB53B648244FC32C00F006E3 /* RemoteHeaders.h in Resources */,
 				BB53B642244FC08F00F006E3 /* RemoteCapture.h in Resources */,

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -979,6 +979,7 @@
 				INFOPLIST_FILE = InjectionBundle/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/$(SWIFT_PLATFORM_TARGET_PREFIX) /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks";
+				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionBundle;
@@ -1004,6 +1005,7 @@
 				INFOPLIST_FILE = InjectionBundle/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/$(SWIFT_PLATFORM_TARGET_PREFIX) /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks";
+				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionBundle;
 				PRODUCT_NAME = macOSInjection;

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>3104</string>
+	<string>3122</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>3100</string>
+	<string>3104</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>3078</string>
+	<string>3100</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you want to build this project from source (which you may need to do to use i
 | ------------- | ------------- | ------------- |
 | [Mac app store](https://itunes.apple.com/app/injectioniii/id1380446739?mt=12) | [Release Candidate](https://github.com/johnno1962/InjectionIII/releases) | [Install  Injection.jar](https://github.com/johnno1962/InjectionIII/tree/master/AppCodePlugin) |
 
-### Limitations
+### Limitations/FAQ
 
 This new release of InjectionIII uses a [different patching technique](http://johnholdsworth.com/dyld_dynamic_interpose.html) than previous versions in that you can now update the implementations of class, struct and enum methods (final or not) provided they have not been inlined which shouldn't be the case for a debug build. You can't however alter the layout of a class or struct in the course of an injection i.e. add or rearrange properties with storage or add or move methods of a non-final class or your app will likely crash. Also, see the notes below for injecting `SwiftUI` views and how they require type erasure.
 
@@ -68,7 +68,27 @@ If you have a complex project including Objective-C dependancies you may get the
 ```
 Can't find ordinal for imported symbol for architecture x86_64
 ```
-If this is the case, remove the `-interposable` flag and you will only be able to non-final class methods.
+If this is the case, remove the `-interposable` flag and you will only be able to non-final class methods as the new injection technique will not be available.
+
+If you inject code which calls a function with default arguments you may
+get an error starting as follows reporting an undefined symbol:
+
+```
+*** dlopen() error: dlopen(...
+```
+If you encounter this problem, download and build [the unhide project](https://github.com/johnno1962/unhide) then add the following
+as a "Run Script", "Build Phase" to your project:
+
+```
+UNHIDE=~/bin/unhide.sh
+if [ -f $UNHIDE ]; then
+    $UNHIDE
+else
+    echo "File $UNHIDE used for code Injection does not exist. Download and build the https://github.com/johnno1962/unhide project."
+fi
+```
+This changes the visibility of symbols for default argument generators
+and this issue should disappear.
 
 If you are using Code Coverage, you may need to disable it or you will receive a:
 >	`Symbol not found: ___llvm_profile_runtime` error.`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Xcode 10.2 and later (Swift 5+):
 	#endif
 ```
 
+If you'd rather not modify your project source you can edit your Xcode run `scheme` and add an environment variable
+`DYLD_INSERT_LIBRARIES` under the `Arguments` tab with the following value instead of the bundle loads above:
+
+`/Applications/InjectionIII.app/Contents/Resources/iOSInjection.bundle/iOSInjection`
+
 Adding one of these lines loads a bundle included in the `InjectionIII.app`'s
 resources which connects over a localhost socket to the InjectionII app which runs on the task bar.
 Once injection is connected, you'll be prompted to select the directory containing the project file for the app you wish to inject. This starts a `file watcher` for that directory inside the Mac app so whenever
@@ -74,7 +79,10 @@ If you inject code which calls a function with default arguments you may
 get an error starting as follows reporting an undefined symbol:
 
 ```
-*** dlopen() error: dlopen(...
+💉 *** dlopen() error: dlopen(/var/folders/nh/gqmp6jxn4tn2tyhwqdcwcpkc0000gn/T/com.johnholdsworth.InjectionIII/eval101.dylib, 2): Symbol not found: _$s13TestInjection15QTNavigationRowC4text10detailText4icon6object13customization6action21accessoryButtonActionACyxGSS_AA08QTDetailG0OAA6QTIconOSgypSgySo15UITableViewCellC_AA5QTRow_AA0T5StyleptcSgyAaT_pcSgAWtcfcfA1_
+ Referenced from: /var/folders/nh/gqmp6jxn4tn2tyhwqdcwcpkc0000gn/T/com.johnholdsworth.InjectionIII/eval101.dylib
+ Expected in: flat namespace
+in /var/folders/nh/gqmp6jxn4tn2tyhwqdcwcpkc0000gn/T/com.johnholdsworth.InjectionIII/eval101.dylib ***
 ```
 If you encounter this problem, download and build [the unhide project](https://github.com/johnno1962/unhide) then add the following
 as a "Run Script", "Build Phase" to your project:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ has been built into a standalone app: `InjectionIII.app` which runs in the statu
 
 ### Getting Started
 
-To use injection, download and run the app and you must add `"-Xlinker -interposable"` to your project's `"Other Linker Flags"` for the Debug target qualified by the simulator SDK (to avoid complications with bitcode). Then, add one of the following to your application delegate's `applicationDidFinishLaunching:`
+To use injection, download and run the app and you must add `"-Xlinker -interposable"` to your project's `"Other Linker Flags"` for the Debug target (qualified by the simulator SDK to avoid complications with bitcode). Then, add one of the following to your application delegate's `applicationDidFinishLaunching:`
 
 Xcode 10.2 and later (Swift 5+):
 
@@ -61,7 +61,14 @@ If you want to build this project from source (which you may need to do to use i
 
 ### Limitations
 
-This new release of InjectionIII works differently than previous versions in that you can now update the implementations of class, struct and enum methods (final or not) provided they have not been inlined which shouldn't be the case for a debug build. You can't however alter the layout of a class or struct in the course of an injection i.e. add or rearrange properties with storage or add or move methods of a non-final class or your app will likely crash. Also, see the notes below for injecting `SwiftUI` views and how they require type erasure.
+This new release of InjectionIII uses a [different patching technique](http://johnholdsworth.com/dyld_dynamic_interpose.html) than previous versions in that you can now update the implementations of class, struct and enum methods (final or not) provided they have not been inlined which shouldn't be the case for a debug build. You can't however alter the layout of a class or struct in the course of an injection i.e. add or rearrange properties with storage or add or move methods of a non-final class or your app will likely crash. Also, see the notes below for injecting `SwiftUI` views and how they require type erasure.
+
+If you have a complex project including Objective-C dependancies you may get the following error on linking:
+
+```
+Can't find ordinal for imported symbol for architecture x86_64
+```
+If this is the case, remove the `-interposable` flag and you will only be able to non-final class methods.
 
 If you are using Code Coverage, you may need to disable it or you will receive a:
 >	`Symbol not found: ___llvm_profile_runtime` error.`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ has been built into a standalone app: `InjectionIII.app` which runs in the statu
 
 ### Getting Started
 
-To use injection, download and run the app and you must add `"-Xlinker -interposable"` to your project's `"Other Linker Flags"` for the Debug target (qualified by the simulator SDK to avoid complications with bitcode). Then, add one of the following to your application delegate's `applicationDidFinishLaunching:`
+To use injection, download the app from the App Store and run it. Then, and must add `"-Xlinker -interposable"` to your project's `"Other Linker Flags"` for the Debug target (qualified by the simulator SDK to avoid complications with bitcode). Finally, add one of the following to your application delegate's `applicationDidFinishLaunching:`
 
 Xcode 10.2 and later (Swift 5+):
 
@@ -73,7 +73,7 @@ If you have a complex project including Objective-C dependancies you may get the
 ```
 Can't find ordinal for imported symbol for architecture x86_64
 ```
-If this is the case, remove the `-interposable` flag and you will only be able to non-final class methods as the new injection technique will not be available.
+If this is the case, remove the `-interposable` flag and you will only be able to inject non-final class methods as the new injection technique will not be available.
 
 If you inject code which calls a function with default arguments you may
 get an error starting as follows reporting an undefined symbol:


### PR DESCRIPTION
Hi @zenangst, after looking at https://github.com/johnno1962/InjectionIII/issues/201 over TeamView last night it seems best if we enable old style injection on top of the new mechanism for now. This gives people a fallback for when https://github.com/johnno1962/InjectionIII/issues/249 prevents people from using the required -interposable flag ensuring at least class method injection works. I guess we should release this before too long.