### PR TITLE
Fix AppCode compatibility

### DIFF
--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -193,8 +193,6 @@ public class SwiftEval: NSObject {
                 throw evalError("Could not locate derived data. Is the project under your home directory?")
         }
         guard let (projectFile, logsDir) =
-            self.derivedLogs
-                .flatMap({ (URL(fileURLWithPath: self.projectFile!), URL(fileURLWithPath: $0)) }) ??
                 self.projectFile
                     .flatMap({ logsDir(project: URL(fileURLWithPath: $0), derivedData: derivedData) })
                     .flatMap({ (URL(fileURLWithPath: self.projectFile!), $0) }) ??

--- a/InjectionIII/InjectionServer.swift
+++ b/InjectionIII/InjectionServer.swift
@@ -160,6 +160,7 @@ public class InjectionServer: SimpleSocket {
                 }
             }
             self.lastIdeProcPath = ideProcPath
+            self.builder.lastIdeProcPath = ideProcPath
             if (automatic) {
                 self.injectPending()
             }


### PR DESCRIPTION
I found that the latest version of Injection doesn't work with AppCode (we are making a video for the same text tutorial, so was checking it). Found the following: a) SwiftEval.lastIdeProcPath is not set in the main application, fixed it b) `derivedLogs` are set only once to Xcode logs, and it doesn't work with dynamic IDE identification (here I'm completely not sure, why was it working before), so I tried to make it always depend on `derivedData` variable. 