### PR TITLE
Trace collections, include legacy injection

### DIFF
--- a/InjectionBundle/SwiftEval.swift
+++ b/InjectionBundle/SwiftEval.swift
@@ -5,7 +5,7 @@
 //  Created by John Holdsworth on 02/11/2017.
 //  Copyright © 2017 John Holdsworth. All rights reserved.
 //
-//  $Id: //depot/ResidentEval/InjectionBundle/SwiftEval.swift#151 $
+//  $Id: //depot/ResidentEval/InjectionBundle/SwiftEval.swift#152 $
 //
 //  Basic implementation of a Swift "eval()" including the
 //  mechanics of recompiling a class and loading the new
@@ -547,7 +547,7 @@ public class SwiftEval: NSObject {
                         if ($line =~ /^\\s*cd /) {
                             $realPath = $line;
                         }
-                        elsif ($line =~ m@\(regexp.escaping("\"$"))@oi and $line =~ " \(arch)") {
+                        elsif ($line =~ m@\(regexp.escaping("\"$"))@oi and $line =~ " \(arch)" and $line !~ /watchos/) {
                             # found compile command
                             # may need to extract file list
                             if ($line =~ / -filelist /) {

--- a/InjectionBundle/SwiftInjection.swift
+++ b/InjectionBundle/SwiftInjection.swift
@@ -5,7 +5,7 @@
 //  Created by John Holdsworth on 05/11/2017.
 //  Copyright © 2017 John Holdsworth. All rights reserved.
 //
-//  $Id: //depot/ResidentEval/InjectionBundle/SwiftInjection.swift#110 $
+//  $Id: //depot/ResidentEval/InjectionBundle/SwiftInjection.swift#111 $
 //
 //  Cut-down version of code injection in Swift. Uses code
 //  from SwiftEval.swift to recompile and reload class.
@@ -16,13 +16,13 @@ import Foundation
 import SwiftTrace
 
 /** pointer to a function implementing a Swift method */
-public typealias SIMP = SwiftTrace.SIMP
-public typealias ClassMetadataSwift = SwiftTrace.TargetClassMetadata
+public typealias SIMP = SwiftMeta.SIMP
+public typealias ClassMetadataSwift = SwiftMeta.TargetClassMetadata
 
 #if swift(>=3.0)
 public func _stdlib_demangleName(_ mangledName: String) -> String {
     return mangledName.withCString {
-        SwiftTrace.demangle(symbol: $0) ?? mangledName }
+        SwiftMeta.demangle(symbol: $0) ?? mangledName }
 }
 #endif
 
@@ -131,9 +131,9 @@ public class SwiftInjection: NSObject {
 
             // overwrite Swift vtable of existing class with implementations from new class
             let existingClass = unsafeBitCast(oldClass, to:
-                UnsafeMutablePointer<SwiftTrace.TargetClassMetadata>.self)
+                UnsafeMutablePointer<ClassMetadataSwift>.self)
             let classMetadata = unsafeBitCast(newClass, to:
-                UnsafeMutablePointer<SwiftTrace.TargetClassMetadata>.self)
+                UnsafeMutablePointer<ClassMetadataSwift>.self)
 
             // Is this a Swift class?
             // Reference: https://github.com/apple/swift/blob/master/include/swift/ABI/Metadata.h#L1195
@@ -146,7 +146,7 @@ public class SwiftInjection: NSObject {
                     print("💉 ⚠️ Adding or removing methods on Swift classes is not supported. Your application will likely crash. ⚠️")
                 }
 
-                #if false // replaced by "interpose" code below
+                #if true // replaced by "interpose" code below
                 func byteAddr<T>(_ location: UnsafeMutablePointer<T>) -> UnsafeMutablePointer<UInt8> {
                     return location.withMemoryRebound(to: UInt8.self, capacity: 1) { $0 }
                 }
@@ -224,7 +224,7 @@ public class SwiftInjection: NSObject {
                     let current = SwiftTrace.interposed(replacee: existing) else {
                     return
                 }
-                let method = SwiftTrace.demangle(symbol: symbol) ?? String(cString: symbol)
+                let method = SwiftMeta.demangle(symbol: symbol) ?? String(cString: symbol)
                 if detail {
                     print("💉 Replacing \(method)")
                 }
@@ -432,7 +432,7 @@ public class SwiftInjection: NSObject {
         for suffix in SwiftTrace.swiftFunctionSuffixes {
             findSwiftSymbols(Bundle.main.executablePath!, suffix) {
                 (_, symname: UnsafePointer<Int8>, _, _) in
-                if let sym = SwiftTrace.demangle(symbol: String(cString: symname)),
+                if let sym = SwiftMeta.demangle(symbol: String(cString: symname)),
                     !sym.hasPrefix("(extension in "),
                     let endPackage = sym.firstIndex(of: ".") {
                     packages.insert(sym[..<(endPackage+0)])

--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -1393,7 +1393,7 @@
 				INFOPLIST_FILE = InjectionIII/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 2.4.4;
+				MARKETING_VERSION = 2.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionIII;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1416,7 +1416,7 @@
 				INFOPLIST_FILE = InjectionIII/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 2.4.4;
+				MARKETING_VERSION = 2.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionIII;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5140</string>
+	<string>5149</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5074</string>
+	<string>5128</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/Info.plist
+++ b/InjectionIII/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>5128</string>
+	<string>5140</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/InjectionIII/build_bundles.sh
+++ b/InjectionIII/build_bundles.sh
@@ -6,7 +6,7 @@
 #  Created by John Holdsworth on 04/10/2019.
 #  Copyright © 2019 John Holdsworth. All rights reserved.
 #
-#  $Id: //depot/ResidentEval/InjectionIII/build_bundles.sh#52 $
+#  $Id: //depot/ResidentEval/InjectionIII/build_bundles.sh#54 $
 #
 
 # Injection has to assume a fixed path for Xcode.app as it uses
@@ -42,5 +42,5 @@ rsync -au $SYMROOT/$CONFIGURATION/SwiftTrace.framework/{Headers,Modules,Versions
 rsync -au $SYMROOT/$CONFIGURATION-iphonesimulator/SwiftTrace.framework/{Headers,Modules} "$CODESIGNING_FOLDER_PATH/Contents/Resources/iOSInjection.bundle/Frameworks/SwiftTrace.framework" &&
 rsync -au $SYMROOT/$CONFIGURATION-appletvsimulator/SwiftTrace.framework/{Headers,Modules} "$CODESIGNING_FOLDER_PATH/Contents/Resources/tvOSInjection.bundle/Frameworks/SwiftTrace.framework" &&
 # This seems to be a bug producing .swiftinterface files.
-perl -pi.bak -e 's/SwiftTrace.(SwiftTrace|dyld_interpose_tuple)/$1/g'  $CODESIGNING_FOLDER_PATH/Contents/Resources/{macOSInjection.bundle/Contents,{i,tv}OSInjection.bundle}/Frameworks/SwiftTrace.framework/Modules/*/*.swiftinterface &&
+perl -pi.bak -e 's/SwiftTrace.(Swift(Trace|Meta)|dyld_interpose_tuple)/$1/g' $CODESIGNING_FOLDER_PATH/Contents/Resources/{macOSInjection.bundle/Contents,{i,tv}OSInjection.bundle}/Frameworks/SwiftTrace.framework/Modules/*/*.swiftinterface &&
 find $CODESIGNING_FOLDER_PATH/Contents/Resources/*.bundle -name '*.bak' -delete


### PR DESCRIPTION
Ongoing work on SwiftTrace and type discovery for tracing and I've turned legacy injection back on to be less reliant on the -Xlinker flag for user's first impressions. I've prepared a [draft release](https://github.com/johnno1962/InjectionIII/releases/tag/untagged-c2f03d88bf8cd074aaa6) if you have time to test it. Not much actually changed with injection itself.