### PR TITLE
Support for custom Xcode app path

### DIFF
--- a/InjectionIII.xcodeproj/project.pbxproj
+++ b/InjectionIII.xcodeproj/project.pbxproj
@@ -1511,7 +1511,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = InjectionBundle/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
-				LD_RUNPATH_SEARCH_PATHS = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $PLATFORM_DIR/Developer/Library/Frameworks @loader_path/../Frameworks";
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionBundle;
@@ -1535,7 +1535,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = InjectionBundle/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
-				LD_RUNPATH_SEARCH_PATHS = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $PLATFORM_DIR/Developer/Library/Frameworks @loader_path/../Frameworks";
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.johnholdsworth.InjectionBundle;

--- a/InjectionIII/Base.lproj/MainMenu.xib
+++ b/InjectionIII/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -664,7 +664,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -679,11 +679,11 @@
                         <action selector="autoInject:" target="Voe-Tx-rLC" id="YDX-ZY-Oim"/>
                     </connections>
                 </menuItem>
-                <menuItem title="Open Project" toolTip="Select Project directory to watch for file edits" id="XlL-4Y-oKk">
+                <menuItem title="Open Project" toolTip="Select Project directory to watch for file edits" id="ogq-jl-5tV">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <accessibility description="Open Project"/>
                     <connections>
-                        <action selector="openProject:" target="Voe-Tx-rLC" id="ZLH-lf-p4H"/>
+                        <action selector="openProject:" target="Voe-Tx-rLC" id="Vic-Ez-zP0"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Open Recent" id="tXI-mr-wws">
@@ -704,6 +704,13 @@
                     <accessibility description="Add Project"/>
                     <connections>
                         <action selector="addDirectory:" target="Voe-Tx-rLC" id="Z4L-RL-lKH"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Select Xcode" toolTip="Select Project directory to watch for file edits" id="XlL-4Y-oKk" userLabel="Select Xcode">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <accessibility description="Select Xcode"/>
+                    <connections>
+                        <action selector="selectXcode:" target="Voe-Tx-rLC" id="L05-t8-pwX"/>
                     </connections>
                 </menuItem>
                 <menuItem title="File Watcher" state="on" toolTip="Enable/Disable file watcher" id="0iA-WA-gxc">
@@ -977,7 +984,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="1940" y="1086" width="376" height="166"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="Qow-ez-PwQ">
                 <rect key="frame" x="0.0" y="0.0" width="376" height="166"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/InjectionIII/build_bundles.sh
+++ b/InjectionIII/build_bundles.sh
@@ -9,17 +9,12 @@
 #  $Id: //depot/ResidentEval/InjectionIII/build_bundles.sh#67 $
 #
 
-# Injection has to assume a fixed path for Xcode.app as it uses
-# Swift and the user's project may contain only Objective-C.
-# The second "rpath" is to be able to find XCTest.framework.
-FIXED_XCODE_DEVELOPER_PATH=/Applications/Xcode.app/Contents/Developer
-
 function build_bundle () {
     FAMILY=$1
     PLATFORM=$2
     SDK=$3
-    SWIFT_DYLIBS_PATH="$FIXED_XCODE_DEVELOPER_PATH/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$SDK"
-    XCTEST_FRAMEWORK_PATH="$FIXED_XCODE_DEVELOPER_PATH/Platforms/$PLATFORM.platform/Developer/Library/Frameworks"
+    SWIFT_DYLIBS_PATH="$TOOLCHAIN_DIR/usr/lib/swift/$SDK"
+    XCTEST_FRAMEWORK_PATH="$PLATFORM_DIR/Developer/Library/Frameworks"
     BUNDLE_CONFIG=Release
 
     if [ ! -d "$SWIFT_DYLIBS_PATH" -o ! -d "${XCTEST_FRAMEWORK_PATH}/XCTest.framework" ]; then

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You should use one of these releases for Apple Silicon or if you have upgraded t
 
 ![Icon](http://johnholdsworth.com/InjectionUI.gif)
 
-`InjectionIII.app` needs an Xcode 10.2 or greater at the path `/Applications/Xcode.app` , 
+`InjectionIII.app` needs an Xcode 10.2 or greater, 
 works for `Swift`,  `Objective-C` and since 3.2.2 `C++` and can be used alongside [AppCode](https://www.jetbrains.com/help/objc/create-a-swiftui-application.html) or by using the [AppCode Plugin](https://github.com/johnno1962/InjectionIII/blob/master/AppCodePlugin/INSTALL.md)
 instead.
 


### PR DESCRIPTION
[This PR](https://github.com/johnno1962/HotReloading/pull/55) first please 🙏

**Problem**
Sometimes developers has several installed xcode version on their local machines: Xcode_13.4.1.app, Xcode_13.2.1.app etc.

**Previous solution**
As a workaround developers can create symlink as described 
[here](https://github.com/johnno1962/InjectionIII/issues/403#issuecomment-1156464874).
But unfortunately this solution doesn't work well in case the developer has more than one version of Xcode with main one installed as Xcode.app

**Solution**
In this PR is implemented the ability to give the developer an option to select a path to desired installed Xcode version